### PR TITLE
added wrap dependency file for dftd4

### DIFF
--- a/dftd4.wrap
+++ b/dftd4.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = dftd4
+url = https://github.com/dftd4/dftd4.git
+revision = head

--- a/meson.build
+++ b/meson.build
@@ -198,6 +198,13 @@ d4lib_shared = shared_library(meson.project_name(),
                  link_whole : d4lib_static,
                  install : true)
 
+# dependency declaration for wrap
+dftd4_dependency = [declare_dependency(link_with: d4lib_shared), dependencies_sha]
+
+# optional static depenendency for wrap
+dftd4_dependency_static = [declare_dependency(link_with: d4lib_static),
+                           dependencies_exe]
+
 # and link it into an executable
 d4exe = executable(meson.project_name(), fmain,
                  dependencies : dependencies_exe,

--- a/meson.build
+++ b/meson.build
@@ -199,11 +199,11 @@ d4lib_shared = shared_library(meson.project_name(),
                  install : true)
 
 # dependency declaration for wrap
-dftd4_dependency = [declare_dependency(link_with: d4lib_shared), dependencies_sha]
+dftd4_dep = [declare_dependency(link_with: d4lib_shared), dependencies_sha]
 
 # optional static depenendency for wrap
-dftd4_dependency_static = [declare_dependency(link_with: d4lib_static),
-                           dependencies_exe]
+dftd4_dep_static = [declare_dependency(link_with: d4lib_static),
+                    dependencies_exe]
 
 # and link it into an executable
 d4exe = executable(meson.project_name(), fmain,


### PR DESCRIPTION
see [meson wrap](https://mesonbuild.com/Wrap-dependency-system-manual.html#wrapgit) for details.
- [x] allows building dftd4 as subproject with other meson based projects
- [x] example wrap file provided to use wrap-git on this repo