### PR TITLE
split ASE calculator from actual ctypes interface implementation

### DIFF
--- a/python/dftd4/interface.py
+++ b/python/dftd4/interface.py
@@ -1,0 +1,342 @@
+# This file is part of dftd4.
+#
+# Copyright (C) 2019 Sebastian Ehlert
+#
+# dftd4 is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# dftd4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
+"""Wrapper around the C-API of the dftd4 shared library."""
+
+from typing import Optional
+
+from ctypes import Structure, c_int, c_double, c_bool, c_char_p, \
+                   POINTER, cdll, CDLL
+from ctypes.util import find_library
+
+import numpy as np
+
+__all__ = [
+    'DFTDOptions',
+    'DFTDParameters',
+    'DFTD4Library',
+    'P_REFQ_EEQ',
+    'P_MBD_NONE',
+    'P_MBD_RPALIKE',
+    'P_MBD_APPROX_ATM',
+]
+__DFTD4_LIBRARY_NAME__ = find_library('dftd4') or 'libdftd4.so'
+
+P_REFQ_EEQ = 5
+
+P_MBD_NONE = 0
+P_MBD_RPALIKE = 1
+P_MBD_APPROX_ATM = 3
+
+
+class _Structure_(Structure):  # pylint: disable=invalid-name,protected-access
+    """patch Structure class to allow returning it arguments as dict."""
+    def to_dict(self) -> dict:
+        """return structure as dictionary."""
+        return {key: getattr(self, key) for key, _ in self._fields_}
+
+    def to_list(self) -> list:
+        """return structure as list. Order is the same as in structure."""
+        return [getattr(self, key) for key, _ in self._fields_]
+
+
+class DFTDParameters(_Structure_):
+    """DFTD damping parameters"""
+    _fields_ = [
+        ('s6', c_double),
+        ('s8', c_double),
+        ('s10', c_double),
+        ('a1', c_double),
+        ('a2', c_double),
+        ('s9', c_double),
+        ('alp', c_int),
+        ('beta', c_double),
+    ]
+
+
+class DFTDOptions(_Structure_):
+    """Options for the dftd4 library"""
+    _fields_ = [
+        ('lmbd', c_int),
+        ('refq', c_int),
+        ('wf', c_double),
+        ('g_a', c_double),
+        ('g_c', c_double),
+        ('properties', c_bool),
+        ('energy', c_bool),
+        ('forces', c_bool),
+        ('hessian', c_bool),
+        ('print_level', c_int),
+    ]
+
+
+def check_ndarray(array: np.ndarray, ctype, size: int, name="array") -> None:
+    """check if we got the correct array data"""
+    if not isinstance(array, np.ndarray):
+        raise ValueError("{} must be of type ndarray".format(name))
+    if array.size != size:
+        raise ValueError("{} does not have the correct size of {}"
+                         .format(name, size))
+    if np.ctypeslib.as_ctypes_type(array.dtype) != ctype:
+        raise ValueError("{} must be of {} compatible type"
+                         .format(name, ctype.__class__.__name__))
+
+
+class DFTD4Library:
+    """wrapper for the dftd4 shared library"""
+
+    _D4_calculation_ = (
+        POINTER(c_int),  # number of atoms
+        POINTER(c_int),  # atomic numbers, dimension(number of atoms)
+        POINTER(c_double),  # molecular charge
+        POINTER(c_double),  # cartesian coordinates, dimension(3*number of atoms)
+        c_char_p,  # output file name
+        POINTER(DFTDParameters),
+        POINTER(DFTDOptions),
+        POINTER(c_double),  # energy
+        POINTER(c_double),  # gradient, dimension(3*number of atoms)
+        POINTER(c_double),  # hessian, dimension((3*number of atoms)**2)
+        POINTER(c_double),  # polarizibilities, dimension(number of atoms)
+        POINTER(c_double),  # C6-coefficients, dimension(number of atoms**2)
+        POINTER(c_double),  # partial charges, dimension(number of atoms)
+    )
+
+    _D4_PBC_calculation_ = (
+        POINTER(c_int),  # number of atoms
+        POINTER(c_int),  # atomic numbers, dimension(number of atoms)
+        POINTER(c_double),  # molecular charge
+        POINTER(c_double),  # cartesian coordinates, dimension(3*number of atoms)
+        POINTER(c_double),  # lattice parameters, dimension(9)
+        POINTER(c_bool),  # periodicity of the system
+        c_char_p,  # output file name
+        POINTER(DFTDParameters),
+        POINTER(DFTDOptions),
+        POINTER(c_double),  # energy
+        POINTER(c_double),  # gradient, dimension(3*number of atoms)
+        POINTER(c_double),  # lattice gradient, dimension(9)
+        POINTER(c_double),  # stress tensor, dimension(9)
+        POINTER(c_double),  # hessian, dimension((3*number of atoms)**2)
+        POINTER(c_double),  # polarizibilities, dimension(number of atoms)
+        POINTER(c_double),  # C6-coefficients, dimension(number of atoms**2)
+        POINTER(c_double),  # partial charges, dimension(number of atoms)
+    )
+
+    _D4_damping_parameters_ = (
+        c_char_p,
+        POINTER(DFTDParameters),
+        POINTER(c_int),
+    )
+
+    _D3_calculation_ = (
+        POINTER(c_int),  # number of atoms
+        POINTER(c_int),  # atomic numbers, dimension(number of atoms)
+        POINTER(c_double),  # cartesian coordinates, dimension(3*number of atoms)
+        c_char_p,  # output file name
+        POINTER(DFTDParameters),
+        POINTER(DFTDOptions),
+        POINTER(c_double),  # energy
+        POINTER(c_double),  # gradient, dimension(3*number of atoms)
+        POINTER(c_double),  # hessian, dimension((3*number of atoms)**2)
+        POINTER(c_double),  # polarizibilities, dimension(number of atoms)
+        POINTER(c_double),  # C6-coefficients, dimension(number of atoms**2)
+    )
+
+    _D3_PBC_calculation_ = (
+        POINTER(c_int),  # number of atoms
+        POINTER(c_int),  # atomic numbers, dimension(number of atoms)
+        POINTER(c_double),  # cartesian coordinates, dimension(3*number of atoms)
+        POINTER(c_double),  # lattice parameters, dimension(9)
+        POINTER(c_bool),  # periodicity of the system
+        c_char_p,  # output file name
+        POINTER(DFTDParameters),
+        POINTER(DFTDOptions),
+        POINTER(c_double),  # energy
+        POINTER(c_double),  # gradient, dimension(3*number of atoms)
+        POINTER(c_double),  # lattice gradient, dimension(9)
+        POINTER(c_double),  # stress tensor, dimension(9)
+        POINTER(c_double),  # hessian, dimension((3*number of atoms)**2)
+        POINTER(c_double),  # polarizibilities, dimension(number of atoms)
+        POINTER(c_double),  # C6-coefficients, dimension(number of atoms**2)
+    )
+
+    def __init__(self, library: Optional[CDLL] = None):
+        """construct library from CDLL object."""
+        if library is None:
+            library = cdll.LoadLibrary(__DFTD4_LIBRARY_NAME__)
+
+        self.library = library
+        self._set_argtypes_()
+
+    def _set_argtypes_(self) -> None:
+        """define all interfaces."""
+        self.library.D4_PBC_calculation.argtypes = self._D4_PBC_calculation_
+        self.library.D4_calculation.argtypes = self._D4_calculation_
+        self.library.D4_damping_parameters.argtypes = self._D4_damping_parameters_
+        self.library.D3_PBC_calculation.argtypes = self._D3_PBC_calculation_
+        self.library.D3_calculation.argtypes = self._D3_calculation_
+
+    # pylint: disable=invalid-name, too-many-arguments, too-many-locals
+    def D4Calculation(self, natoms: int, numbers, positions, options: dict,
+                      charge: float = 0.0, output: str = "-",
+                      cell=None, pbc=None) -> dict:
+        """wrapper for calling the D4 Calculator from the library."""
+        periodic = cell is not None and pbc is not None
+
+        check_ndarray(numbers, c_int, natoms, "numbers")
+        check_ndarray(positions, c_double, 3*natoms, "positions")
+        if periodic:
+            check_ndarray(cell, c_double, 9, "cell")
+        if periodic:
+            check_ndarray(pbc, c_bool, 3, "pbc")
+
+        energy = c_double(0.0)
+        gradient = np.zeros((natoms, 3), dtype=c_double)
+        charges = np.zeros(natoms, dtype=c_double)
+        polarizibilities = np.zeros(natoms, dtype=c_double)
+        c6_coefficients = np.zeros((natoms, natoms), dtype=c_double)
+
+        if periodic:
+            cell_gradient = np.zeros((3, 3), dtype=c_double)
+            stress_tensor = np.zeros((3, 3), dtype=c_double)
+            args = [
+                c_int(natoms),
+                numbers.ctypes.data_as(POINTER(c_int)),
+                c_double(charge),
+                positions.ctypes.data_as(POINTER(c_double)),
+                cell.ctypes.data_as(POINTER(c_double)),
+                pbc.ctypes.data_as(POINTER(c_bool)),
+                output.encode('utf-8'),
+                DFTDParameters(**options),
+                DFTDOptions(**options),
+                energy,
+                gradient.ctypes.data_as(POINTER(c_double)),
+                None,
+                stress_tensor.ctypes.data_as(POINTER(c_double)),
+                cell_gradient.ctypes.data_as(POINTER(c_double)),
+                polarizibilities.ctypes.data_as(POINTER(c_double)),
+                c6_coefficients.ctypes.data_as(POINTER(c_double)),
+                charges.ctypes.data_as(POINTER(c_double)),
+            ]
+            stat = self.library.D4_PBC_calculation(*args)
+        else:
+            args = [
+                c_int(natoms),
+                numbers.ctypes.data_as(POINTER(c_int)),
+                c_double(charge),
+                positions.ctypes.data_as(POINTER(c_double)),
+                output.encode('utf-8'),
+                DFTDParameters(**options),
+                DFTDOptions(**options),
+                energy,
+                gradient.ctypes.data_as(POINTER(c_double)),
+                None,
+                polarizibilities.ctypes.data_as(POINTER(c_double)),
+                c6_coefficients.ctypes.data_as(POINTER(c_double)),
+                charges.ctypes.data_as(POINTER(c_double)),
+            ]
+            stat = self.library.D4_calculation(*args)
+
+        if stat != 0:
+            raise RuntimeError("D4 calculation failed in dftd4.")
+
+        results = {
+            'energy': energy.value,
+            'gradient': gradient,
+            'polarizibilities': polarizibilities,
+            'c6_coefficients': c6_coefficients,
+            'charges': charges,
+        }
+        if periodic:
+            results['cell gradient'] = cell_gradient
+            results['stress tensor'] = stress_tensor
+        return results
+
+    def D4Parameters(self, functional: str, lmbd: int = P_MBD_APPROX_ATM) -> dict:
+        """load damping parameters from dftd4 shared library"""
+        dparam = DFTDParameters()
+        stat = self.library.D4_damping_parameters(functional.encode('utf-8'),
+                                                  dparam, c_int(lmbd))
+        if stat == 0:
+            return dparam.to_dict()
+        return {}
+
+    # pylint: disable=invalid-name, too-many-arguments, too-many-locals
+    def D3Calculation(self, natoms: int, numbers, positions, options: dict,
+                      output: str = "-", cell=None, pbc=None) -> dict:
+        """wrapper for calling the D3 Calculator from the library."""
+        periodic = cell is not None and pbc is not None
+
+        check_ndarray(numbers, c_int, natoms, "numbers")
+        check_ndarray(positions, c_double, 3*natoms, "positions")
+        if periodic:
+            check_ndarray(cell, c_double, 9, "cell")
+            check_ndarray(pbc, c_bool, 3, "pbc")
+
+        energy = c_double(0.0)
+        gradient = np.zeros((natoms, 3), dtype=c_double)
+        polarizibilities = np.zeros(natoms, dtype=c_double)
+        c6_coefficients = np.zeros((natoms, natoms), dtype=c_double)
+
+        if periodic:
+            cell_gradient = np.zeros((3, 3), dtype=c_double)
+            stress_tensor = np.zeros((3, 3), dtype=c_double)
+            args = [
+                c_int(natoms),
+                numbers.ctypes.data_as(POINTER(c_int)),
+                positions.ctypes.data_as(POINTER(c_double)),
+                cell.ctypes.data_as(POINTER(c_double)),
+                pbc.ctypes.data_as(POINTER(c_bool)),
+                output.encode('utf-8'),
+                DFTDParameters(**options),
+                DFTDOptions(**options),
+                energy,
+                gradient.ctypes.data_as(POINTER(c_double)),
+                None,
+                stress_tensor.ctypes.data_as(POINTER(c_double)),
+                cell_gradient.ctypes.data_as(POINTER(c_double)),
+                polarizibilities.ctypes.data_as(POINTER(c_double)),
+                c6_coefficients.ctypes.data_as(POINTER(c_double)),
+            ]
+            stat = self.library.D3_PBC_calculation(*args)
+        else:
+            args = [
+                c_int(natoms),
+                numbers.ctypes.data_as(POINTER(c_int)),
+                positions.ctypes.data_as(POINTER(c_double)),
+                output.encode('utf-8'),
+                DFTDParameters(**options),
+                DFTDOptions(**options),
+                energy,
+                gradient.ctypes.data_as(POINTER(c_double)),
+                None,
+                polarizibilities.ctypes.data_as(POINTER(c_double)),
+                c6_coefficients.ctypes.data_as(POINTER(c_double)),
+            ]
+            stat = self.library.D3_calculation(*args)
+
+        if stat != 0:
+            raise RuntimeError("D3 calculation failed in dftd4.")
+
+        results = {
+            'energy': energy.value,
+            'gradient': gradient,
+            'polarizibilities': polarizibilities,
+            'c6_coefficients': c6_coefficients,
+        }
+        if periodic:
+            results['cell gradient'] = cell_gradient
+            results['stress tensor'] = stress_tensor
+        return results

--- a/python/dftd4/test/test_calculators.py
+++ b/python/dftd4/test/test_calculators.py
@@ -15,9 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-Tests for the ASE interface to dftd4.
-"""
+"""Tests for the ASE interface to dftd4."""
 
 def test_d4_molecular():
     """Short test for DFT-D4 on a subset of the G2."""
@@ -55,74 +53,6 @@ def test_d4_molecular():
         assert abs(atoms.get_forces().flatten()).mean() == approx(gnorm, thr)
     # print(table)
     # assert 0
-
-
-def test_load_D4_damping_parameters():
-    """check if we can load parameters from the shared object"""
-    from dftd4.calculators import D4_model, DFTDParameters
-
-    funcs = {'pbe0': {'s6': 1.0, 's8': 1.20065498, 's10': 0.0, 'a1': 0.40085597,
-                      'a2': 5.02928789, 's9': 1.0, 'alp': 16, 'beta': 1.0},
-             'b3lyp': {'s6': 1.0, 's8': 2.02929367, 's10': 0.0, 'a1': 0.40868035,
-                       'a2': 4.53807137, 's9': 1.0, 'alp': 16, 'beta': 1.0},
-             'B3-LYP': {'s6': 1.0, 's8': 2.02929367, 's10': 0.0, 'a1': 0.40868035,
-                        'a2': 4.53807137, 's9': 1.0, 'alp': 16, 'beta': 1.0},
-             'PwpB95': {'s6': 0.82, 's8': -0.34639127, 's10': 0.0,
-                        'a1': 0.41080636, 'a2': 3.83878274, 's9': 1.0, 'alp': 16,
-                        'beta': 1.0},
-             'Lh07sSVWN': {'s6': 1.0, 's8': 3.16675531, 's10': 0.0,
-                           'a1': 0.35965552, 'a2': 4.31947614, 's9': 1.0,
-                           'alp': 16, 'beta': 1.0},
-             'revPBE': {'s6': 1.0, 's8': 1.7467653, 's10': 0.0, 'a1': 0.536349,
-                        'a2': 3.07261485, 's9': 1.0, 'alp': 16, 'beta': 1.0}}
-
-    calc = D4_model()
-    for func in funcs:
-        calc.load_damping_parameters(func)
-        assert funcs[func] == calc.get_struct(DFTDParameters).to_dict()
-
-
-def test_load_dftd4_library():
-    """check the ctypes library loader"""
-    from ctypes.util import find_library
-    from dftd4.calculators import load_dftd4_library
-    lib = load_dftd4_library()
-    assert lib is not None
-    path = find_library('dftd4')
-    lib = load_dftd4_library(path)
-    assert lib is not None
-
-
-def test_structs():
-    """test if structures are robust against input"""
-    from dftd4.calculators import DFTDParameters, DFTDOptions
-
-    parameters = {'s6': 1.0, 's8': 1.44956635, 'a1': 0.32704579, 'a2': 5.36988013,
-                  's9': 1.0, 'alp': 16, 's10': 0.0, 'beta': 1.0,
-                  'wrong_key': 'stuff'}
-    dparam = DFTDParameters(**parameters).to_dict()
-    del parameters['wrong_key']
-    assert parameters == dparam
-
-    parameters = {'s6': 1.0, 's8': 1.44956635, 'a1': 0.32704579, 'a2': 5.36988013,
-                  's9': 1.0, 'alp': 16}
-    dparam = DFTDParameters(**parameters).to_dict()
-    assert parameters == {key: dparam[key] for key in parameters}
-
-    options = {'lmbd': 3, 'refq': 5, 'wf': 6.0, 'g_a': 3.0, 'g_c': 2.0,
-               'properties': True, 'energy': True, 'forces': True,
-               'hessian': False, 'print_level': 2,
-               'wrong_key': 'stuff'}
-
-    dopt = DFTDOptions(**options).to_dict()
-    del options['wrong_key']
-    assert options == dopt
-
-    options = {'lmbd': 3, 'refq': 5, 'wf': 6.0, 'g_a': 3.0, 'g_c': 2.0,
-               'properties': True, 'energy': True, 'forces': True}
-
-    dopt = DFTDOptions(**options).to_dict()
-    assert options == {key: dopt[key] for key in options}
 
 
 def test_d3_molecular():

--- a/python/dftd4/test/test_interface.py
+++ b/python/dftd4/test/test_interface.py
@@ -20,13 +20,10 @@
 
 def test_library():
     """check if we can find the library and it looks okay"""
-    from ctypes import cdll
-    from ctypes.util import find_library
+    from dftd4.interface import load_library
 
-    name = find_library("dftd4")
-    assert name is not None
     # check if we can load this one
-    lib = cdll.LoadLibrary(name)
+    lib = load_library('libdftd4')
     # check if we find some functions
     assert lib.D4_calculation is not None
     assert lib.D4_PBC_calculation is not None

--- a/python/dftd4/test/test_interface.py
+++ b/python/dftd4/test/test_interface.py
@@ -1,0 +1,223 @@
+# This file is part of dftd4.
+#
+# Copyright (C) 2019 Sebastian Ehlert
+#
+# dftd4 is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# dftd4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the ctypes interface to dftd4."""
+
+
+def test_library():
+    """check if we can find the library and it looks okay"""
+    from ctypes import cdll
+    from ctypes.util import find_library
+
+    name = find_library("dftd4")
+    assert name is not None
+    # check if we can load this one
+    lib = cdll.LoadLibrary(name)
+    # check if we find some functions
+    assert lib.D4_calculation is not None
+    assert lib.D4_PBC_calculation is not None
+    assert lib.D3_calculation is not None
+    assert lib.D3_PBC_calculation is not None
+
+    from dftd4.interface import DFTD4Library
+
+    libdftd4 = DFTD4Library(library=lib)
+    assert libdftd4.library is lib
+    # check if we find some functions
+    assert hasattr(libdftd4, "D4Calculation")
+    assert hasattr(libdftd4, "D3Calculation")
+
+    libdftd4 = DFTD4Library()
+    # check if we find some functions
+    assert hasattr(libdftd4, "D4Calculation")
+    assert hasattr(libdftd4, "D3Calculation")
+
+
+class Testing:
+    """test all defined interfaces"""
+    from ctypes import c_int, c_double
+    from numpy import array
+    from dftd4.interface import DFTD4Library
+
+    natoms = 24
+    numbers = array(
+        [6, 7, 6, 7, 6, 6, 6, 8, 7, 6, 8, 7, 6, 6, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        dtype=c_int,
+    )
+    positions = array(
+        [
+            [2.02799738646442, 0.09231312124713, -0.14310895950963],
+            [4.75011007621000, 0.02373496014051, -0.14324124033844],
+            [6.33434307654413, 2.07098865582721, -0.14235306905930],
+            [8.72860718071825, 1.38002919517619, -0.14265542523943],
+            [8.65318821103610, -1.19324866489847, -0.14231527453678],
+            [6.23857175648671, -2.08353643730276, -0.14218299370797],
+            [5.63266886875962, -4.69950321056008, -0.13940509630299],
+            [3.44931709749015, -5.48092386085491, -0.14318454855466],
+            [7.77508917214346, -6.24427872938674, -0.13107140408805],
+            [10.30229550927022, -5.39739796609292, -0.13672168520430],
+            [12.07410272485492, -6.91573621641911, -0.13666499342053],
+            [10.70038521493902, -2.79078533715849, -0.14148379504141],
+            [13.24597858727017, -1.76969072232377, -0.14218299370797],
+            [7.40891694074004, -8.95905928176407, -0.11636933482904],
+            [1.38702118184179, 2.05575746325296, -0.14178615122154],
+            [1.34622199478497, -0.86356704498496, 1.55590600570783],
+            [1.34624089204623, -0.86133716815647, -1.84340893849267],
+            [5.65596919189118, 4.00172183859480, -0.14131371969009],
+            [14.67430918222276, -3.26230980007732, -0.14344911021228],
+            [13.50897177220290, -0.60815166181684, 1.54898960808727],
+            [13.50780014200488, -0.60614855212345, -1.83214617078268],
+            [5.41408424778406, -9.49239668625902, -0.11022772492007],
+            [8.31919801555568, -9.74947502841788, 1.56539243085954],
+            [8.31511620712388, -9.76854236502758, -1.79108242206824],
+        ],
+        dtype=c_double,
+    )
+    lib = DFTD4Library()
+
+    def test_d4_interface(self):
+        """check if the D4 interface is working correctly."""
+        thr = 1.0e-8
+        from pytest import approx
+        from dftd4.interface import P_MBD_APPROX_ATM, P_REFQ_EEQ
+
+        options = {
+            'lmbd': P_MBD_APPROX_ATM,
+            'refq': P_REFQ_EEQ,
+            'wf': 6.0,
+            'g_a': 3.0,
+            'g_c': 2.0,
+            'properties': True,
+            'energy': True,
+            'forces': True,
+            'hessian': False,
+            'print_level': 1,
+            's6': 1.0000,  # B3LYP-D4-ATM parameters
+            's8': 1.93077774,
+            's9': 1.0,
+            's10': 0.0,
+            'a1': 0.40520781,
+            'a2': 4.46255249,
+            'alp': 16,
+        }
+        kwargs = {
+            "natoms": self.natoms,
+            "numbers": self.numbers,
+            "charge": 0.0,
+            "positions": self.positions,
+            "options": options,
+            "output": "-",
+        }
+        results = self.lib.D4Calculation(**kwargs)
+        assert results
+        gnorm = abs(results["gradient"].flatten()).mean()
+        assert approx(results["energy"], thr) == -0.04928342326381067
+        assert approx(gnorm, thr) == 0.0002453003088176903
+
+    def test_d3_interface(self):
+        """check if the D3 interface is working correctly."""
+        thr = 1.0e-8
+        from pytest import approx
+        from dftd4.interface import P_MBD_APPROX_ATM, P_REFQ_EEQ
+
+        options = {
+            'lmbd': P_MBD_APPROX_ATM,
+            'refq': P_REFQ_EEQ,
+            'wf': 4.0,
+            'g_a': 0.0,
+            'g_c': 0.0,
+            'properties': True,
+            'energy': True,
+            'forces': True,
+            'hessian': False,
+            'print_level': 1,
+            's6': 1.0000,  # B3LYP-D3-ATM parameters
+            's8': 2.17707910,
+            's9': 1.0,
+            's10': 0.0,
+            'a1': 0.31888091,
+            'a2': 4.85097930,
+            'alp': 16,
+        }
+        kwargs = {
+            "natoms": self.natoms,
+            "numbers": self.numbers,
+            "positions": self.positions,
+            "options": options,
+            "output": "-",
+        }
+        results = self.lib.D3Calculation(**kwargs)
+        assert results
+        gnorm = abs(results["gradient"].flatten()).mean()
+        assert approx(results["energy"], thr) == -0.049193282449077516
+        assert approx(gnorm, thr) == 0.0003855527267206884
+
+
+def test_load_D4_damping_parameters():
+    """check if we can load parameters from the shared object"""
+    from dftd4.interface import DFTD4Library
+
+    funcs = {'pbe0': {'s6': 1.0, 's8': 1.20065498, 's10': 0.0, 'a1': 0.40085597,
+                      'a2': 5.02928789, 's9': 1.0, 'alp': 16, 'beta': 1.0},
+             'b3lyp': {'s6': 1.0, 's8': 2.02929367, 's10': 0.0, 'a1': 0.40868035,
+                       'a2': 4.53807137, 's9': 1.0, 'alp': 16, 'beta': 1.0},
+             'B3-LYP': {'s6': 1.0, 's8': 2.02929367, 's10': 0.0, 'a1': 0.40868035,
+                        'a2': 4.53807137, 's9': 1.0, 'alp': 16, 'beta': 1.0},
+             'PwpB95': {'s6': 0.82, 's8': -0.34639127, 's10': 0.0,
+                        'a1': 0.41080636, 'a2': 3.83878274, 's9': 1.0, 'alp': 16,
+                        'beta': 1.0},
+             'Lh07sSVWN': {'s6': 1.0, 's8': 3.16675531, 's10': 0.0,
+                           'a1': 0.35965552, 'a2': 4.31947614, 's9': 1.0,
+                           'alp': 16, 'beta': 1.0},
+             'revPBE': {'s6': 1.0, 's8': 1.7467653, 's10': 0.0, 'a1': 0.536349,
+                        'a2': 3.07261485, 's9': 1.0, 'alp': 16, 'beta': 1.0}}
+
+    library = DFTD4Library()
+    for func in funcs:
+        assert funcs[func] == library.D4Parameters(func)
+
+
+def test_structs():
+    """test if structures are robust against input"""
+    from dftd4.interface import DFTDParameters, DFTDOptions
+
+    parameters = {'s6': 1.0, 's8': 1.44956635, 'a1': 0.32704579, 'a2': 5.36988013,
+                  's9': 1.0, 'alp': 16, 's10': 0.0, 'beta': 1.0,
+                  'wrong_key': 'stuff'}
+    dparam = DFTDParameters(**parameters).to_dict()
+    del parameters['wrong_key']
+    assert parameters == dparam
+
+    parameters = {'s6': 1.0, 's8': 1.44956635, 'a1': 0.32704579, 'a2': 5.36988013,
+                  's9': 1.0, 'alp': 16}
+    dparam = DFTDParameters(**parameters).to_dict()
+    assert parameters == {key: dparam[key] for key in parameters}
+
+    options = {'lmbd': 3, 'refq': 5, 'wf': 6.0, 'g_a': 3.0, 'g_c': 2.0,
+               'properties': True, 'energy': True, 'forces': True,
+               'hessian': False, 'print_level': 2,
+               'wrong_key': 'stuff'}
+
+    dopt = DFTDOptions(**options).to_dict()
+    del options['wrong_key']
+    assert options == dopt
+
+    options = {'lmbd': 3, 'refq': 5, 'wf': 6.0, 'g_a': 3.0, 'g_c': 2.0,
+               'properties': True, 'energy': True, 'forces': True}
+
+    dopt = DFTDOptions(**options).to_dict()
+    assert options == {key: dopt[key] for key in options}

--- a/python/dftd4/utils.py
+++ b/python/dftd4/utils.py
@@ -1,0 +1,71 @@
+# This file is part of dftd4.
+#
+# Copyright (C) 2019 Sebastian Ehlert
+#
+# dftd4 is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# dftd4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Utilities for working with dftd4-data.
+"""
+
+from math import exp
+
+
+def extrapolate_c8_coeff(c6_coeff: float, iat: int, jat: int) -> float:
+    """C6 -> C8 extrapolation"""
+    from dftd4.data import sqrt_z_r4_over_r2 as r4r2
+    return 3.0 * r4r2[iat] * r4r2[jat] * c6_coeff
+
+
+def extrapolate_c10_coeff(c6_coeff: float, iat: int, jat: int) -> float:
+    """C8 -> C10 extrapolation"""
+    c8_coeff: float = extrapolate_c8_coeff(c6_coeff, iat, jat)
+    return 49.0 / 40.0 * c8_coeff * c8_coeff / c6_coeff
+
+
+def extrapolate_c_n_coeff(c6_coeff: float, iat: int, jat: int, n_order: int)\
+        -> float:
+    """extrapolation of higher C_n"""
+    if n_order == 6:
+        return c6_coeff
+    if n_order == 8:
+        return extrapolate_c8_coeff(c6_coeff, iat, jat)
+    if n_order == 10:
+        return extrapolate_c10_coeff(c6_coeff, iat, jat)
+    if n_order % 2 == 0 and n_order > 10:
+        cfrac: float = extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-2) / \
+                       extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-4)
+        return extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-6) * cfrac**3
+    raise ValueError("This is no valid C_n-coefficient")
+
+
+def cn_gaussian_weight(weighting_factor: float, cni: float, cnref: float) -> float:
+    """coordination number based gaussian weight"""
+    return exp(-weighting_factor*(cni-cnref)**2)
+
+
+def gompertz_function(scale: float, gamma: float, zref: float, zmod: float) \
+                      -> float:
+    """bare scaling function used in dftd4"""
+    return exp(scale * (1 - exp(gamma * (1 - zref/zmod))))
+
+
+def zeta_scaling(g_a: float, g_c: float, charge: float, ref_charge: float,
+                 iat: int) -> float:
+    """wrapper for scaling function to account for constants and limiting case"""
+    from dftd4.data import def2ecp_nuclear_charges, chemical_hardness
+    zeff: float = def2ecp_nuclear_charges[iat]
+    gamma: float = g_c * chemical_hardness[iat]
+    if zeff+charge > 0.0:
+        return gompertz_function(g_a, gamma, zeff+ref_charge, zeff+charge)
+    return exp(g_a)

--- a/python/dftd4/utils.py
+++ b/python/dftd4/utils.py
@@ -14,11 +14,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
-"""
-Utilities for working with dftd4-data.
-"""
+"""Utilities for working with dftd4-data."""
 
 from math import exp
+from dftd4.data import def2ecp_nuclear_charges, chemical_hardness
 
 
 def extrapolate_c8_coeff(c6_coeff: float, iat: int, jat: int) -> float:
@@ -29,7 +28,7 @@ def extrapolate_c8_coeff(c6_coeff: float, iat: int, jat: int) -> float:
 
 def extrapolate_c10_coeff(c6_coeff: float, iat: int, jat: int) -> float:
     """C8 -> C10 extrapolation"""
-    c8_coeff: float = extrapolate_c8_coeff(c6_coeff, iat, jat)
+    c8_coeff = extrapolate_c8_coeff(c6_coeff, iat, jat)
     return 49.0 / 40.0 * c8_coeff * c8_coeff / c6_coeff
 
 
@@ -43,8 +42,8 @@ def extrapolate_c_n_coeff(c6_coeff: float, iat: int, jat: int, n_order: int)\
     if n_order == 10:
         return extrapolate_c10_coeff(c6_coeff, iat, jat)
     if n_order % 2 == 0 and n_order > 10:
-        cfrac: float = extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-2) / \
-                       extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-4)
+        cfrac = extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-2) / \
+                extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-4)
         return extrapolate_c_n_coeff(c6_coeff, iat, jat, n_order-6) * cfrac**3
     raise ValueError("This is no valid C_n-coefficient")
 
@@ -63,9 +62,8 @@ def gompertz_function(scale: float, gamma: float, zref: float, zmod: float) \
 def zeta_scaling(g_a: float, g_c: float, charge: float, ref_charge: float,
                  iat: int) -> float:
     """wrapper for scaling function to account for constants and limiting case"""
-    from dftd4.data import def2ecp_nuclear_charges, chemical_hardness
-    zeff: float = def2ecp_nuclear_charges[iat]
-    gamma: float = g_c * chemical_hardness[iat]
+    zeff = def2ecp_nuclear_charges[iat]
+    gamma = g_c * chemical_hardness[iat]
     if zeff+charge > 0.0:
         return gompertz_function(g_a, gamma, zeff+ref_charge, zeff+charge)
     return exp(g_a)


### PR DESCRIPTION
- new interface wrapping the shared library
- more tests for interface
- python 3.5 compatibility
  - [x] remove `find_library` and replace it with something working
- OSX compatibility
  - [x] remove `numpy.ctypeslib` since it seems to be not available on OSX