### PR TITLE
Install Fortran mod-files to include/ directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -223,6 +223,16 @@ if asciidoc.found()
    install_man('man1/dftd4.1')
 endif
 
+fobjs = []
+foreach file: fsrcs
+  fobjs += '@0@.o'.format('_'.join(file.split('/')))
+endforeach
+message(fobjs)
+install_subdir(meson.current_build_dir()/'@0@@sta'.format(meson.project_name()),
+               install_dir: 'include',
+               strip_directory: true,
+               exclude_files: fobjs)
+
 ## ========================================== ##
 ## TESTSUITE
 ## ========================================== ##


### PR DESCRIPTION
Use workaround from https://github.com/mesonbuild/meson/issues/5374#issuecomment-497709445 to install Fortran module files.