### PR TITLE
add JSON and TOML serialization for results type

### DIFF
--- a/man1/dftd4.1.txt
+++ b/man1/dftd4.1.txt
@@ -62,6 +62,12 @@ OPTIONS
 *--orca*::
      Enter compatibility mode for ORCA
 
+*--json*::
+     Serialize all results as JSON (dftd4.json)
+
+*--toml*::
+     Serialize all results as TOML (dftd4.toml)
+
 *--tmer*::
      Force tmer2++ compatible .EDISP printout
 

--- a/source/argparser.f90
+++ b/source/argparser.f90
@@ -174,6 +174,8 @@ subroutine read_commandline_arguments(env,set)
          case('-g','--grad'); set%lgradient = .true.
          case(     '--hess');  set%lhessian = .true.
          case(     '--orca');   set%lorca = .true.
+         case(     '--json'); set%json = .true.
+         case(     '--toml'); set%toml = .true.
 
 ! ------------------------------------------------------------------------
 !  no match => take as file name

--- a/source/class_set.f90
+++ b/source/class_set.f90
@@ -84,6 +84,8 @@ module class_set
       logical  :: lgradient = .false.       !< calculate dispersion gradient?
       logical  :: lhessian = .false.        !< calculate dispersion hessian?
       integer  :: print_level = 1           !< print more information
+      logical  :: json = .false.            !< dump calculation data as JSON
+      logical  :: toml = .false.            !< dump calculation data as TOML
    contains
       procedure :: default_options
       procedure :: export => export_dftd_options

--- a/source/printout.f90
+++ b/source/printout.f90
@@ -173,6 +173,10 @@ subroutine help(iunit)
       "        force tmer2++ compatible .EDISP printout",&
       "    --orca",&
       "        ORCA compatibility mode (for usage by the orca binary)",&
+      "    --json",&
+      "        serialize all results as JSON (dftd4.json)",&
+      "    --toml",&
+      "        serialize all results as TOML (dftd4.toml)",&
       "    --molc6",&
       "        calculate dispersion related properties (default)",&
    !$ "-P, --parallel <integer>",&

--- a/source/program_dftd.f90
+++ b/source/program_dftd.f90
@@ -60,7 +60,7 @@ program dftd
 !  local variables
 ! ------------------------------------------------------------------------
    integer  :: ndim                      ! matrix dimension
-   integer  :: i,j,k,l,ii,jj
+   integer  :: i,j,k,l,ii,jj,io
    integer  :: err
    real(wp) :: memory
    real(wp) :: etmp,etwo,emany,er,el,es
@@ -214,6 +214,18 @@ if (set%lenergy.or.set%lgradient.or.set%lhessian) &
    if (set%lhessian) then
       call orca_hessian(mol,istdout,dresults%hessian)
    endif
+
+   if (set%json) then
+      open(file='dftd4.json', newunit=io)
+      call dresults%write_json(io, '  ')
+      close(io)
+   end if
+
+   if (set%toml) then
+      open(file='dftd4.toml', newunit=io)
+      call dresults%write_toml(io, ' ')
+      close(io)
+   end if
 
    call env%checkpoint
    call env%write('Some non-fatal runtime exceptions occurred, please check:')


### PR DESCRIPTION
This allows to serialize all results from `dftd4` to JSON (flag: `--json`) or TOML (flag: `--toml`).

Fixes #37