### PR TITLE
Fix F2018 warnings seen with ifort

### DIFF
--- a/source/mctc_strings.f90
+++ b/source/mctc_strings.f90
@@ -161,7 +161,7 @@ pure subroutine shiftstr(str,n)
    integer :: lenstr,nabs
 
    lenstr=len(str)
-   nabs=iabs(n)
+   nabs=abs(n)
    if(nabs>=lenstr) then
       str=repeat(' ',lenstr)
       return

--- a/source/pbc_tools.f90
+++ b/source/pbc_tools.f90
@@ -364,7 +364,7 @@ pure function minimum_image_distance(lsame,fi,fj,dlat,lpbc) result(dist)
 
    else
       do idir = 1, 3
-         if (lpbc(idir)) fij(idir) = fij(idir) - idnint(fij(idir))
+         if (lpbc(idir)) fij(idir) = fij(idir) - nint(fij(idir))
       enddo
 
       rij = matmul(dlat,fij)


### PR DESCRIPTION
mctc_strings.f90(164): warning #8891: Specific names for intrinsic procedures are obsolescent in Fortran 2018.   [IABS]
pbc_tools.f90(367): warning #8891: Specific names for intrinsic procedures are obsolescent in Fortran 2018.   [IDNINT]