### PR TITLE
Enable continuous delivery of statically linked dftd4 versions

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -156,6 +156,7 @@ jobs:
       env:
         OMP_NUM_THREADS: 2,1
 
+  # Build with Intel toolchain
   intel-build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -172,6 +173,7 @@ jobs:
         intel-oneapi-compiler-fortran
         intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         intel-oneapi-mkl-devel
+        asciidoctor
 
     steps:
     - name: Checkout code
@@ -195,11 +197,16 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
 
-    - name: Install meson/cmake
-      run: pip3 install meson==0.56.2 ninja
+    - name: Install meson
+      run: pip3 install meson==0.57.1 ninja
 
     - name: Configure meson build
-      run: meson setup ${{ env.BUILD_DIR }} -Dfortran_link_args=-qopenmp
+      run: >-
+        meson setup ${{ env.BUILD_DIR }}
+        --prefix=/
+        --libdir=lib
+        --default-library=static
+        -Dfortran_link_args="-static -qopenmp"
 
     - name: Build library
       run: meson compile -C ${{ env.BUILD_DIR }}
@@ -208,3 +215,102 @@ jobs:
       run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild
       env:
         OMP_NUM_THREADS: 2,1
+
+    - name: Install package
+      run: meson install -C ${{ env.BUILD_DIR }} --no-rebuild
+      env:
+        DESTDIR: ${{ env.PWD }}/dftd4-bleed
+
+    - name: Create package
+      if: github.event_name == 'push'
+      run: |
+        tar cvf dftd4-bleed.tar dftd4-bleed
+        xz --threads=4 dftd4-bleed.tar
+
+    - name: Upload binary
+      if: github.event_name == 'push'
+      uses: actions/upload-artifact@v2
+      with:
+        name: dftd4-bleed.tar.xz
+        path: dftd4-bleed.tar.xz
+
+  # Inspired from https://github.com/endless-sky/endless-sky
+  continuous-delivery:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs:
+      - intel-build
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: bleed
+      OUTPUT_INTEL: dftd4-bleed.tar.xz
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install github-release
+      run: |
+        go get github.com/github-release/github-release
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+    - name: Set environment variables
+      run: |
+        echo "GITHUB_USER=$( echo ${{ github.repository }} | cut -d/ -f1 )" >> $GITHUB_ENV
+        echo "GITHUB_REPO=$( echo ${{ github.repository }} | cut -d/ -f2 )" >> $GITHUB_ENV
+
+    - name: Move/Create continuous tag
+      run: |
+        git tag --force ${{ env.RELEASE_TAG }} ${{ github.sha }}
+        git push --tags --force
+
+    - name: Get Time
+      run: echo "TIME=$(date -u '+%Y/%m/%d, %H:%M')" >> $GITHUB_ENV
+
+    - name: Check continuous release status
+      run: |
+        if ! github-release info -t ${{ env.RELEASE_TAG }} > /dev/null 2>&1; then
+          echo "RELEASE_COMMAND=release" >> $GITHUB_ENV
+        else
+          echo "RELEASE_COMMAND=edit" >> $GITHUB_ENV
+        fi
+
+    - name: Setup continuous release
+      run: >-
+        github-release ${{ env.RELEASE_COMMAND }}
+        --tag ${{ env.RELEASE_TAG }}
+        --name "Bleeding edge version"
+        --description "$DESCRIPTION"
+        --pre-release
+      env:
+        DESCRIPTION: |
+          Created on ${{ env.TIME }} UTC by @${{ github.actor }} with commit ${{ github.sha }}.
+          This is an automated distribution of the latest `dftd4` version. It contains the latest features and possibly also the newest bugs. Use with caution!
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: ${{ github.workspace }} # This will download all files
+
+    - name: Create SHA256 checksum
+      run: |
+        cd ${{ env.OUTPUT_INTEL }}
+        sha256sum ${{ env.OUTPUT_INTEL }} > sha256.txt
+
+    - name: Add ${{ env.OUTPUT_INTEL }} to release tag
+      run: >-
+        github-release upload
+        --tag ${{ env.RELEASE_TAG }}
+        --replace
+        --name ${{ env.OUTPUT_INTEL }}
+        --file ${{ env.OUTPUT_INTEL }}/${{ env.OUTPUT_INTEL }}
+
+    - name: Add SHA256 checksums to release tag
+      run: >-
+        github-release upload
+        --tag ${{ env.RELEASE_TAG }}
+        --replace
+        --name sha256.txt
+        --file ${{ env.OUTPUT_INTEL }}/sha256.txt

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -225,7 +225,7 @@ jobs:
       if: github.event_name == 'push'
       run: |
         tar cvf dftd4-bleed.tar dftd4-bleed
-        xz --threads=4 dftd4-bleed.tar
+        xz --threads=0 dftd4-bleed.tar
 
     - name: Upload binary
       if: github.event_name == 'push'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Generally Applicable Atomic-Charge Dependent London Dispersion Correction.
 ## Installing
 
 A statically linked binary distribution for Linux platforms is available at the [latest release](https://github.com/dftd4/dftd4/releases/latest) tag.
+Bleeding edge releases of the latest source from this repository are available on the [continuous release tag](https://github.com/dftd4/dftd4/releases/tag/bleed).
 
 
 ### Conda package


### PR DESCRIPTION
Create a bleeding edge release for new DFT-D4 version to allow easier testing. This feature is enabled on push, meaning developers enabling actions on their fork are able to use this workflow to create local versions of their branches.