### PR TITLE
Allow to link against mkl_rt library

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -79,6 +79,10 @@ if lapack_vendor == 'mkl'
   mkl_dep += fc.find_library('mkl_core')
   lib_deps += mkl_dep
 
+elif lapack_vendor == 'mkl-rt'
+  mkl_dep = fc.find_library('mkl_rt')
+  lib_deps += mkl_dep
+
 elif lapack_vendor == 'openblas'
   openblas_dep = dependency('openblas', required: false)
   if not openblas_dep.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,7 +19,7 @@ option(
   type: 'combo',
   value: 'auto',
   yield: true,
-  choices: ['auto', 'mkl', 'openblas', 'netlib'],
+  choices: ['auto', 'mkl', 'mkl-rt', 'openblas', 'netlib'],
   description : 'linear algebra backend',
 )
 

--- a/subprojects/multicharge.wrap
+++ b/subprojects/multicharge.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = multicharge
 url = https://github.com/grimme-lab/multicharge
-revision = v0.1.0
+revision = v0.1.1


### PR DESCRIPTION
- Python extension module must be linked against `mkl_rt` to work correctly with MKL