### PR TITLE
Add install script for module files

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -27,9 +27,11 @@ test('app-license', dftd4_exe, args: '--license')
 test('app-citation', dftd4_exe, args: '--citation')
 test('app-noargs', dftd4_exe, should_fail: true)
 
+app_tester = find_program(files('tester.py'))
+
 test(
   'app-energy',
-  files('tester.py'),
+  app_tester,
   args: [
     dftd4_exe,
     files('energy.json'),
@@ -40,7 +42,7 @@ test(
 )
 test(
   'app-gradient',
-  files('tester.py'),
+  app_tester,
   args: [
     dftd4_exe,
     files('gradient.json'),
@@ -53,7 +55,7 @@ test(
 )
 test(
   'app-properties',
-  files('tester.py'),
+  app_tester,
   args: [
     dftd4_exe,
     files('properties.json'),
@@ -62,7 +64,7 @@ test(
 )
 test(
   'app-pair-analysis',
-  files('tester.py'),
+  app_tester,
   args: [
     dftd4_exe,
     files('pair-analysis.json'),

--- a/config/install-mod.py
+++ b/config/install-mod.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the Lesser GNU General Public License
 # along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
 
-import os, sys, shutil
 from os import environ, listdir, makedirs
 from os.path import join, isdir, exists
 from sys import argv
@@ -27,7 +26,7 @@ if "MESON_INSTALL_DESTDIR_PREFIX" in environ:
 else:
     install_dir = environ["MESON_INSTALL_PREFIX"]
 
-include_dir = sys.argv[1] if len(sys.argv) > 1 else "include"
+include_dir = argv[1] if len(argv) > 1 else "include"
 module_dir = join(install_dir, include_dir)
 
 modules = []

--- a/config/install-mod.py
+++ b/config/install-mod.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python
+# This file is part of dftd4.
+# SPDX-Identifier: LGPL-3.0-or-later
+#
+# dftd4 is free software: you can redistribute it and/or modify it under
+# the terms of the Lesser GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# dftd4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Lesser GNU General Public License for more details.
+#
+# You should have received a copy of the Lesser GNU General Public License
+# along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
 
-print("Starting...")
 import os, sys, shutil
 from os import environ, listdir, makedirs
 from os.path import join, isdir, exists

--- a/config/install-mod.py
+++ b/config/install-mod.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+print("Starting...")
+import os, sys, shutil
+from os import environ, listdir, makedirs
+from os.path import join, isdir, exists
+from sys import argv
+from shutil import copy
+
+build_dir = environ["MESON_BUILD_ROOT"]
+if "MESON_INSTALL_DESTDIR_PREFIX" in environ:
+    install_dir = environ["MESON_INSTALL_DESTDIR_PREFIX"]
+else:
+    install_dir = environ["MESON_INSTALL_PREFIX"]
+
+include_dir = sys.argv[1] if len(sys.argv) > 1 else "include"
+module_dir = join(install_dir, include_dir)
+
+modules = []
+for d in listdir(build_dir):
+    bd = join(build_dir, d)
+    if isdir(bd):
+        for f in listdir(bd):
+            if f.endswith(".mod"):
+                modules.append(join(bd, f))
+
+if not exists(module_dir):
+    makedirs(module_dir)
+
+for mod in modules:
+    print("Installing", mod, "to", module_dir)
+    copy(mod, module_dir)

--- a/meson.build
+++ b/meson.build
@@ -79,10 +79,17 @@ if install
     dftd4_header,
   )
 
+  module_id = meson.project_name() / fc_id + '-' + fc.version()
+  meson.add_install_script(
+    find_program(files('config'/'install-mod.py')),
+    get_option('includedir') / module_id,
+  )
+
   pkg = import('pkgconfig')
   pkg.generate(
     dftd4_lib,
     description: 'Generally Applicable Atomic-Charge Dependent London Dispersion Correction',
+    subdirs: ['', module_id],
   )
 
   asciidoc = find_program('asciidoctor', required: false)


### PR DESCRIPTION
- use the fact that only the dftd4 library is build at the toplevel
- find all module files in the toplevel directories in the build dir