### PR TITLE
Increase required meson version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To compile this version of DFT-D4 the following programs are needed
 
 To build this project from the source code in this repository you need to have
 - a Fortran compiler supporting Fortran 2008
-- [meson](https://mesonbuild.com) version 0.53 or newer
+- [meson](https://mesonbuild.com) version 0.55 or newer
 - a build-system backend, *i.e.* [ninja](https://ninja-build.org) version 1.7 or newer
 - a LAPACK / BLAS provider, like MKL or OpenBLAS
 

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ project(
   'fortran',
   version: '3.2.0',
   license: 'LGPL-3.0-or-later',
-  meson_version: '>=0.53',
+  meson_version: '>=0.55',
   default_options: [
     'buildtype=debugoptimized',
     'default_library=both',

--- a/python/README.rst
+++ b/python/README.rst
@@ -227,7 +227,7 @@ This directory contains a separate meson build file to allow the out-of-tree bui
 The out-of-tree build requires
 
 - C compiler to build the C-API and compile the extension module
-- `meson <https://mesonbuild.com>`_ version 0.53 or newer
+- `meson <https://mesonbuild.com>`_ version 0.55 or newer
 - a build-system backend, *i.e.* `ninja <https://ninja-build.org>`_ version 1.7 or newer
 - Python 3.6 or newer with the `CFFI <https://cffi.readthedocs.io/>`_ package installed
 

--- a/python/meson.build
+++ b/python/meson.build
@@ -20,7 +20,7 @@ project(
   'dftd4-python',
   'c',
   license: 'LGPL-3.0-or-later',
-  meson_version: '>=0.53',
+  meson_version: '>=0.55',
   default_options: [
     'buildtype=debugoptimized',
   ],


### PR DESCRIPTION
Install script for module files requires at least 0.55.x