### PR TITLE
Allow linking against custom linear algebra backend

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -89,7 +89,12 @@ elif lapack_vendor == 'openblas'
     lib_deps += lapack_dep
   endif
 
-elif lapack_vendor == 'netlib'
+elif lapack_vendor == 'custom'
+  foreach lib: get_option('custom_libraries')
+    lib_deps += fc.find_library(lib)
+  endforeach
+
+else
   lapack_dep = dependency('lapack', required: false)
   if not lapack_dep.found()
     lapack_dep = fc.find_library('lapack')
@@ -100,11 +105,6 @@ elif lapack_vendor == 'netlib'
     blas_dep = fc.find_library('blas')
   endif
   lib_deps += blas_dep
-
-else
-  foreach lib: get_option('custom_libraries')
-    lib_deps += fc.find_library(lib)
-  endforeach
 endif
 
 # Create the tool chain library as subproject

--- a/config/meson.build
+++ b/config/meson.build
@@ -78,7 +78,7 @@ elif lapack_vendor == 'mkl-rt'
 elif lapack_vendor == 'openblas'
   openblas_dep = dependency('openblas', required: false)
   if not openblas_dep.found()
-    openblas_dep = fc.find_library('openblas_dep')
+    openblas_dep = fc.find_library('openblas')
   endif
   lib_deps += openblas_dep
   if not fc.links('external dsytrs; call dsytrs(); end', dependencies: openblas_dep)
@@ -89,7 +89,7 @@ elif lapack_vendor == 'openblas'
     lib_deps += lapack_dep
   endif
 
-else
+elif lapack_vendor == 'netlib'
   lapack_dep = dependency('lapack', required: false)
   if not lapack_dep.found()
     lapack_dep = fc.find_library('lapack')
@@ -100,6 +100,11 @@ else
     blas_dep = fc.find_library('blas')
   endif
   lib_deps += blas_dep
+
+else
+  foreach lib: get_option('custom_libraries')
+    lib_deps += fc.find_library(lib)
+  endforeach
 endif
 
 # Create the tool chain library as subproject

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,8 +19,16 @@ option(
   type: 'combo',
   value: 'auto',
   yield: true,
-  choices: ['auto', 'mkl', 'mkl-rt', 'openblas', 'netlib'],
+  choices: ['auto', 'mkl', 'mkl-rt', 'openblas', 'netlib', 'custom'],
   description : 'linear algebra backend',
+)
+
+option(
+  'custom_libraries',
+  type: 'array',
+  value: [],
+  yield: true,
+  description: 'libraries to load for custom linear algebra backend',
 )
 
 option(


### PR DESCRIPTION
Fixes OpenBLAS finder and allows `-Dlapack=custom -Dcustom_libraries=blis,lapack`.