### PR TITLE
Simplify Python setup process

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -218,6 +218,12 @@ To install extra dependencies as well use
 
    pip install '.[parameters,ase,qcschema]'
 
+If you already have a ``dftd4`` installation, *e.g.* from conda-forge, you can build the Python extension module directly without cloning this repository
+
+.. code:: sh
+
+   pip install "https://github.com/dftd4/dftd4/archive/refs/heads/main#egg=dftd4-python&subdirectory=python"
+
 
 
 Using meson

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -26,8 +26,6 @@ classifiers =
 
 [options]
 packages = find:
-setup_requires =
-    pkgconfig
 install_requires =
     cffi
     numpy


### PR DESCRIPTION
This should allow to install the Python API with pip using

```
pip install "https://github.com/dftd4/dftd4/archive/refs/heads/main#egg=dftd4-python&subdirectory=python"
```

It will require an existing `dftd4` installation, though. Chances for success can be improved by installing `pkgconfig`, setting `DFTD4_PREFIX` to the directory where the installation can be found or providing a C compiler in the `CC` environment variable. None of those are mandatory as we try to fall back to reasonable defaults, but those defaults might not be where `dftd4` is actually installed.