### PR TITLE
Add compatibility layer for integration with Vasp

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -72,6 +72,7 @@ jobs:
         -Db_coverage=true
         -Dlapack=netlib
         -Dpython=true
+        -Dapi_v2=true
 
     - name: Build library
       run: meson compile -C ${{ env.M_BUILD_DIR }}

--- a/README.md
+++ b/README.md
@@ -157,6 +157,50 @@ ABI compatibility is only guaranteed for the same minor version.
 The communication with the Fortran API uses the `error_type` and `structure_type` of the modular computation tool chain library (mctc-lib) to handle errors and represent geometries, respectively.
 
 
+#### Building Vasp with support for D4
+
+To use ``dftd4`` in Vasp the compatibility layer for the 2.5.x API has to be enable with ``-Dapi_v2=true`` (meson) or ``-DAPI_V2=ON`` (CMake).
+It is important to build ``dftd4`` with the same Fortran compiler you build Vasp with.
+
+After you completed the installation of ``dftd4`, make sure it is findable by ``pkg-config``, you can check by running:
+
+```
+pkg-config --modversion dftd4
+```
+
+If you ``dftd4`` installation is not findable, you have to update your environment variables.
+One option is to provide a module file for your ``dftd4`` installation.
+The example module file below can be placed in your ``MODULEPATH`` to provide access to an installation in ``~/opt/dftd4/3.2.0``.
+Retry the above comment after loading the ``dftd4`` and adjust the module file until ``pkg-config`` finds your installation.
+
+```lua
+local name = "dftd4"
+local version = "3.2.0"
+local prefix = pathJoin(os.getenv("HOME"), "opt", name, version)
+local libdir = "lib"  -- or lib64
+
+whatis("Name        : " .. name)
+whatis("Version     : " .. version)
+whatis("Description : Generally applicable charge dependent London dispersion correction")
+whatis("URL         : https://github.com/dftd4/dftd4")
+
+prepend_path("PATH", pathJoin(prefix, "bin"))
+prepend_path("MANPATH", pathJoin(prefix, "share", "man"))
+prepend_path("CPATH", pathJoin(prefix, "include"))
+prepend_path("LIBRARY_PATH", pathJoin(prefix, libdir))
+prepend_path("LD_LIBRARY_PATH", pathJoin(prefix, libdir))
+prepend_path("PKG_CONFIG_PATH", pathJoin(prefix, libdir, "pkgconfig"))
+```
+
+To enable support for D4 in Vasp add the following lines to the Makefile:
+
+```make
+CPP_OPTIONS += -DDFTD4
+LLIBS       += $(shell pkg-config --libs dftd4)
+INCS        += $(shell pkg-config --cflags dftd4)
+```
+
+
 ### C API
 
 The C API provides access to the basic Fortran objects and their most important methods to interact with them.

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -18,6 +18,7 @@ option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
 
 option(WITH_API "Enable support for C API via iso_c_binding module" TRUE)
 option(WITH_OpenMP "Enable support for shared memory parallelisation with OpenMP" TRUE)
+option(WITH_API_V2 "Enable the compatibility layer for the dftd4 2.5.x API" FALSE)
 
 set(
   module-dir

--- a/fpm.toml
+++ b/fpm.toml
@@ -27,3 +27,7 @@ tag = "v0.1.2"
 [[test]]
 name = "tester"
 source-dir = "test/unit"
+
+[[test]]
+name = "vasp-compat"
+source-dir = "test/vasp"

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -51,3 +51,10 @@ option(
   value: '3',
   description: 'Python version to link against.',
 )
+
+option(
+  'api_v2',
+  type: 'boolean',
+  value: false,
+  description: 'Enable the compatibility layer for the dftd4 2.5.x API',
+)

--- a/src/dftd4.f90
+++ b/src/dftd4.f90
@@ -15,6 +15,7 @@
 ! along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
 
 module dftd4
+   use mctc_io, only : structure_type, new
    use dftd4_cutoff, only : realspace_cutoff, get_lattice_points
    use dftd4_disp, only : get_dispersion, get_properties, get_pairwise_dispersion
    use dftd4_ncoord, only : get_coordination_number

--- a/src/dftd4/CMakeLists.txt
+++ b/src/dftd4/CMakeLists.txt
@@ -38,5 +38,8 @@ list(
 if(WITH_API)
   list(APPEND srcs "${dir}/api.f90")
 endif()
+if(WITH_API_V2)
+  list(APPEND srcs "${dir}/compat.f90")
+endif()
 
 set(srcs "${srcs}" PARENT_SCOPE)

--- a/src/dftd4/compat.f90
+++ b/src/dftd4/compat.f90
@@ -1,0 +1,215 @@
+! This file is part of dftd4.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! dftd4 is free software: you can redistribute it and/or modify it under
+! the terms of the Lesser GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! dftd4 is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! Lesser GNU General Public License for more details.
+!
+! You should have received a copy of the Lesser GNU General Public License
+! along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
+
+!> This is a compatibility module for dftd4 2.5.0 reproducing enough of the old API
+!> to compile the interface with Vasp.
+module dftd4_compat
+   use mctc_env, only : wp
+   use mctc_io_math, only : matdet_3x3, matinv_3x3
+   use dftd4, only: structure_type, new, d4_model, new_d4_model, rational_damping_param, &
+      & damping_param, get_rational_damping, get_dispersion, realspace_cutoff
+   implicit none
+   private
+
+   public :: dftd_options, dftd_parameter, dftd_results, molecule, mctc_logger, ws_cell
+   public :: dlat_to_cell, dlat_to_dvol, dlat_to_rlat, d4par, d4_calculation
+
+   type :: dftd_options
+      integer :: lmbd = 3
+      integer :: refq = 5
+      real(wp) :: wf = 6.0_wp
+      real(wp) :: g_a
+      real(wp) :: g_c
+      logical :: lmolpol
+      logical :: lenergy
+      logical :: lgradient
+      logical :: lhessian
+      integer :: print_level
+   end type
+
+   type :: dftd_parameter
+      real(wp) :: s6
+      real(wp) :: s8
+      real(wp) :: s9 = 1.0_wp
+      real(wp) :: a1
+      real(wp) :: a2
+      real(wp) :: alp = 16.0_wp
+   end type
+
+   type :: dftd_results
+      real(wp), allocatable :: energy
+      real(wp), allocatable :: gradient(:, :)
+      real(wp), allocatable :: lattice_gradient(:, :)
+   end type
+
+   type :: ws_cell
+   end type
+
+   type :: molecule
+      integer, allocatable :: at(:)
+      real(wp), allocatable :: xyz(:, :)
+      real(wp), allocatable :: lattice(:, :)
+      real(wp), allocatable :: chrg
+      integer, allocatable :: npbc
+      logical, allocatable :: pbc
+      real(wp), allocatable :: volume
+      real(wp), allocatable :: cellpar(:)
+      real(wp), allocatable :: rec_lat(:, :)
+      type(ws_cell) :: wsc
+   contains
+      procedure :: allocate
+      procedure :: wrap_back
+      procedure :: calculate_distances
+   end type
+
+   type :: mctc_logger
+      logical :: sane = .true.
+   end type
+
+contains
+
+subroutine allocate(self, n, l)
+   class(molecule), intent(inout) :: self
+   integer, intent(in) :: n
+   logical, intent(in) :: l
+end subroutine allocate
+
+subroutine wrap_back(self)
+   class(molecule), intent(inout) :: self
+end subroutine wrap_back
+
+subroutine calculate_distances(self)
+   class(molecule), intent(inout) :: self
+end subroutine calculate_distances
+
+subroutine d4_calculation(io, env, options, mol_, param_, res)
+   integer, intent(in) :: io
+   type(mctc_logger), intent(inout) :: env
+   type(dftd_options), intent(in) :: options
+   type(molecule), intent(in) :: mol_
+   type(dftd_parameter), intent(in) :: param_
+   type(dftd_results), intent(out) :: res
+
+   type(structure_type) :: mol
+   type(d4_model) :: d4
+   type(rational_damping_param) :: param
+   real(wp), allocatable :: energy, gradient(:, :), sigma(:, :)
+
+   call new(mol, mol_%at, mol_%xyz, lattice=mol_%lattice)
+   call new_d4_model(d4, mol, ga=options%g_a, gc=options%g_c, wf=options%wf)
+   param = rational_damping_param(&
+      & s6=param_%s6, &
+      & s8=param_%s8, &
+      & s9=param_%s9, &
+      & a1=param_%a1, &
+      & a2=param_%a2, &
+      & alp=param_%alp)
+
+   allocate(energy, gradient(3, mol%nat), sigma(3, 3))
+   call get_dispersion(mol, d4, param, realspace_cutoff(), energy, gradient, sigma)
+   call move_alloc(energy, res%energy)
+   call move_alloc(gradient, res%gradient)
+   res%lattice_gradient = matmul(sigma, transpose(matinv_3x3(mol%lattice)))
+
+end subroutine d4_calculation
+
+subroutine d4par(fname, param_, lmbd, env)
+   character(len=*), intent(in) :: fname
+   type(dftd_parameter), intent(out) :: param_
+   integer, intent(in) :: lmbd
+   type(mctc_logger) :: env
+
+   class(damping_param), allocatable :: param
+
+   call get_rational_damping(fname, param, merge(1.0_wp, 0.0_wp, lmbd == 3))
+   if (allocated(param)) then
+      select type(param)
+      type is(rational_damping_param)
+         env%sane = .true.
+         param_%s6 = param%s6
+         param_%s8 = param%s8
+         param_%s9 = param%s9
+         param_%a1 = param%a1
+         param_%a2 = param%a2
+         param_%alp = param%alp
+      class default
+         env%sane = .false.
+      end select
+   else
+      env%sane = .false.
+   end if
+end subroutine d4par
+
+subroutine dlat_to_cell(lattice, cellpar)
+   real(wp), intent(in) :: lattice(3, 3)
+   real(wp), intent(out), optional :: cellpar(6)
+end subroutine dlat_to_cell
+
+subroutine dlat_to_rlat(lattice, reclatt)
+   real(wp), intent(in) :: lattice(3, 3)
+   real(wp), intent(out), optional :: reclatt(3, 3)
+end subroutine dlat_to_rlat
+
+function dlat_to_dvol(lattice) result(vol)
+   real(wp), intent(in) :: lattice(3, 3)
+   real(wp) :: vol
+   vol = matdet_3x3(lattice)
+end function dlat_to_dvol
+
+end module dftd4_compat
+
+
+subroutine generate_wsc(mol, wsc)
+   use dftd4_compat, only : molecule, ws_cell
+   type(molecule), intent(inout) :: mol
+   type(ws_cell), intent(inout) :: wsc
+end subroutine generate_wsc
+
+module class_set
+   use dftd4_compat, only : dftd_options
+end module class_set
+
+module class_param
+   use dftd4_compat, only : dftd_parameter
+end module class_param
+
+module class_molecule
+   use dftd4_compat, only : molecule
+end module class_molecule
+
+module class_results
+   use dftd4_compat, only : dftd_results
+end module class_results
+
+module class_wsc
+   use dftd4_compat, only : ws_cell
+end module class_wsc
+
+module mctc_environment
+   use dftd4_compat, only : mctc_logger
+end module mctc_environment
+
+module dispersion_calculator
+   use dftd4_compat, only : d4_calculation
+end module dispersion_calculator
+
+module pbc_tools
+   use dftd4_compat, only: dlat_to_cell, dlat_to_dvol, dlat_to_rlat
+end module pbc_tools
+
+module dfuncpar
+   use dftd4_compat, only : d4par
+end module dfuncpar

--- a/src/dftd4/meson.build
+++ b/src/dftd4/meson.build
@@ -35,3 +35,6 @@ srcs += files(
 if get_option('api') or get_option('python')
   srcs += files('api.f90')
 endif
+if get_option('api_v2')
+  srcs += files('compat.f90')
+endif


### PR DESCRIPTION
Add updated `subdftd4.F` and mocked Vasp modules to test compilation.

Closes https://github.com/dftd4/dftd4/issues/85
Closes https://github.com/dftd4/dftd4_vasp/issues/3