### PR TITLE
Add parameters for r²SCAN hybrids

### DIFF
--- a/assets/parameters.toml
+++ b/assets/parameters.toml
@@ -350,6 +350,18 @@ d4.bj-eeq-atm = { s8=0.87728975, a1=0.49116966, a2=5.75859346, doi="10.1063/5.00
 reference.doi = ["10.1021/acs.jpclett.0c02405", "10.1021/acs.jpclett.0c03077"]
 d4.bj-eeq-atm = { s8=0.60187490, a1=0.51559235, a2=5.77342911, doi="10.1063/5.0041008" }
 
+[parameter.r2scanh]
+reference.doi = ["10.1021/acs.jpclett.0c02405", "10.1021/acs.jpclett.0c03077", "10.26434/chemrxiv-2021-cn8lp"]
+d4.bj-eeq-atm = {s8=0.8324, a1=0.4944, a2=5.9019, doi="10.26434/chemrxiv-2021-cn8lp"}
+
+[parameter.r2scan0]
+reference.doi = ["10.1021/acs.jpclett.0c02405", "10.1021/acs.jpclett.0c03077", "10.26434/chemrxiv-2021-cn8lp"]
+d4.bj-eeq-atm = {s8=0.8992, a1=0.4778, a2=5.8779, doi="10.26434/chemrxiv-2021-cn8lp"}
+
+[parameter.r2scan50]
+reference.doi = ["10.1021/acs.jpclett.0c02405", "10.1021/acs.jpclett.0c03077", "10.26434/chemrxiv-2021-cn8lp"]
+d4.bj-eeq-atm = {s8=1.0471, a1=0.4574, a2=5.8969, doi="10.26434/chemrxiv-2021-cn8lp"}
+
 [parameter.tpss0]
 d4.bj-eeq-atm = { s8=1.62438102, a1=0.40329022, a2=4.80537871, doi="10.1063/1.5090222" }
 d4.bj-eeq-mbd = { s8=1.66752698, a1=0.40074746, a2=4.80927196, doi="10.1063/1.5090222" }

--- a/src/dftd4/data/r4r2.f90
+++ b/src/dftd4/data/r4r2.f90
@@ -40,6 +40,7 @@ module dftd4_data_r4r2
    !  not replaced but recalculated (PBE0/cc-pVQZ) were
    !   H: 8.0589 ->10.9359, Li:29.0974 ->39.7226, Be:14.8517 ->17.7460
    !  also new super heavies Cn,Nh,Fl,Lv,Og
+   !  Am-Rg calculated at 4c-PBE/Dyall-AE4Z (Dirac 2022)
    real(wp), parameter :: r4_over_r2(max_elem) = [  &
       &  8.0589_wp, 3.4698_wp, & ! H,He
       & 29.0974_wp,14.8517_wp,11.8799_wp, 7.8715_wp, 5.5588_wp, 4.7566_wp, 3.8025_wp, 3.1036_wp, & ! Li-Ne
@@ -59,10 +60,10 @@ module dftd4_data_r4r2
       &            10.2671_wp, 8.3549_wp, 7.8496_wp, 7.3278_wp, 7.4820_wp, & ! -Hg
       &                       13.5124_wp,11.6554_wp,10.0959_wp, 9.7340_wp, 8.8584_wp, 8.0125_wp, & ! Tl-Rn
       & 29.8135_wp,26.3157_wp, & ! Fr,Ra
-      &            19.1885_wp,15.8542_wp,16.1305_wp,15.6161_wp,15.1226_wp,16.1576_wp, 0.0000_wp, & ! Ac-Am
-      &             0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, & ! Cm-No
-      &             0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, & ! Lr-
-      &             0.0000_wp, 0.0000_wp, 0.0000_wp, 0.0000_wp, 5.4929_wp, & ! -Cn
+      &            19.1885_wp,15.8542_wp,16.1305_wp,15.6161_wp,15.1226_wp,16.1576_wp,14.6510_wp, & ! Ac-Am
+      &            14.7178_wp,13.9108_wp,13.5623_wp,13.2326_wp,12.9189_wp,12.6133_wp,12.3142_wp, & ! Cm-No
+      &            14.8326_wp,12.3771_wp,10.6378_wp, 9.3638_wp, 8.2297_wp, & ! Lr-
+      &             7.5667_wp, 6.9456_wp, 6.3946_wp, 5.9159_wp, 5.4929_wp, & ! -Cn
       &                        6.7286_wp, 6.5144_wp,10.9169_wp,10.3600_wp, 9.4723_wp, 8.6641_wp ] ! Nh-Og
 
    integer :: idum

--- a/src/dftd4/param.f90
+++ b/src/dftd4/param.f90
@@ -50,7 +50,8 @@ module dftd4_param
          & p_m05, p_m052x, p_m08hx, p_lcwhpbe, p_mn12l, p_tauhcthhyb, &
          & p_sogga11x, p_n12sx, p_mn12sx, p_mn15, p_glyp, p_bop, &
          & p_mpw1b95, p_revpbe0dh, p_revtpss0, p_revdsdpbep86, p_revdsdpbe, &
-         & p_revdsdblyp, p_revdodpbep86, p_am05, p_hse12, p_hse12s
+         & p_revdsdblyp, p_revdodpbep86, p_am05, p_hse12, p_hse12s, &
+         & p_r2scanh, p_r2scan0, p_r2scan50
    end enum
    integer, parameter :: df_enum = kind(p_invalid)
 
@@ -422,6 +423,12 @@ subroutine get_d4eeq_bjatm_parameter(dfnum, param, s9)
    case(p_r2scan)
       param = dftd_param ( & ! (10.1063/5.0041008)
          &  s6=1.0000_wp, s8=0.60187490_wp, a1=0.51559235_wp, a2=5.77342911_wp )
+   case(p_r2scanh)
+      param = dftd_param (s6=1.0_wp, s8=0.8324_wp, a1=0.4944_wp, a2=5.9019_wp)
+   case(p_r2scan0)
+      param = dftd_param (s6=1.0_wp, s8=0.8992_wp, a1=0.4778_wp, a2=5.8779_wp)
+   case(p_r2scan50)
+      param = dftd_param (s6=1.0_wp, s8=1.0471_wp, a1=0.4574_wp, a2=5.8969_wp)
    case(p_tpss0)
       param = dftd_param ( & ! (SAW190103)
          &  s6=1.0000_wp, s8=1.62438102_wp, a1=0.40329022_wp, a2=4.80537871_wp )
@@ -581,6 +588,12 @@ pure function get_functional_id(df) result(num)
       num = p_rscan
    case('r2scan', 'r²scan')
       num = p_r2scan
+   case('r2scanh', 'r²scanh')
+      num = p_r2scanh
+   case('r2scan0', 'r²scan0')
+      num = p_r2scan0
+   case('r2scan50', 'r²scan50')
+      num = p_r2scan50
    case('b1lyp', 'b1-lyp')
       num = p_b1lyp
    case('b3-lyp', 'b3lyp')

--- a/test/unit/test_param.f90
+++ b/test/unit/test_param.f90
@@ -96,7 +96,8 @@ subroutine test_rational_damping(error)
       & 'dftb(pbc)', 'dftb(matsci)', 'dftb(ob2)', 'b1b95', 'glyp', 'revpbe0dh', &
       & 'revtpss0', 'revdsd-pbep86', 'revdsd-pbe', 'revdsd-blyp', &
       & 'revdod-pbep86', 'b97m', 'wb97m', 'pbesol', 'am05', 'mn12sx', &
-      & 'hse03', 'hse06', 'hse12', 'hse12s', 'hsesol']
+      & 'hse03', 'hse06', 'hse12', 'hse12s', 'hsesol', 'r2scanh', 'r2scan0', &
+      & 'r2scan50']
    real(wp), parameter :: ref(*) = [&
       &-2.82477943738524E-1_wp,-1.83931932418458E-1_wp,-1.67883732655799E-1_wp, &
       &-1.19260344932822E-1_wp,-1.73553644083274E-1_wp,-4.64187011491173E-1_wp, &
@@ -129,7 +130,8 @@ subroutine test_rational_damping(error)
       &-1.24018193150396E-1_wp,-1.05459213596423E-1_wp,-3.62056545113500E-2_wp, &
       &-3.62056561428035E-2_wp,-2.40058303330640E-2_wp,-6.96544056298022E-2_wp, &
       &-7.14846530839187E-2_wp,-6.94907084631183E-2_wp,-6.20062460023045E-2_wp, &
-      &-5.03611953456781E-2_wp]
+      &-5.03611953456781E-2_wp,-2.92623319798973E-2_wp,-3.16651213971901E-2_wp, &
+      &-3.45136901370079E-2_wp]
    class(damping_param), allocatable :: param
    type(structure_type) :: mol
    integer :: ii


### PR DESCRIPTION
also update r4/r2 expectation values (see https://github.com/awvwgk/simple-dftd3/commit/5642677b691d2496ca7c8deca0ca85b1d56eddd8).