### PR TITLE
pin fetched dependency versions in cmake build

### DIFF
--- a/config/cmake/Findmctc-lib.cmake
+++ b/config/cmake/Findmctc-lib.cmake
@@ -17,6 +17,7 @@
 set(_lib "mctc-lib")
 set(_pkg "MCTCLIB")
 set(_url "https://github.com/grimme-lab/mctc-lib")
+set(_revision "v0.2.3")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")
@@ -29,7 +30,7 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/dftd4-utils.cmake")
 
-dftd4_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}")
+dftd4_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}" "${_revision}")
 
 if(DEFINED "_${_pkg}_FIND_METHOD")
   unset("${_pkg}_FIND_METHOD")
@@ -38,3 +39,4 @@ endif()
 unset(_lib)
 unset(_pkg)
 unset(_url)
+unset(_revision)

--- a/config/cmake/Findmstore.cmake
+++ b/config/cmake/Findmstore.cmake
@@ -17,6 +17,7 @@
 set(_lib "mstore")
 set(_pkg "MSTORE")
 set(_url "https://github.com/grimme-lab/mstore")
+set(_revision "v0.2.0")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")
@@ -29,7 +30,7 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/dftd4-utils.cmake")
 
-dftd4_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}")
+dftd4_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}" "${_revision}")
 
 if(DEFINED "_${_pkg}_FIND_METHOD")
   unset("${_pkg}_FIND_METHOD")
@@ -38,3 +39,4 @@ endif()
 unset(_lib)
 unset(_pkg)
 unset(_url)
+unset(_revision)

--- a/config/cmake/Findmulticharge.cmake
+++ b/config/cmake/Findmulticharge.cmake
@@ -17,6 +17,7 @@
 set(_lib "multicharge")
 set(_pkg "MULTICHARGE")
 set(_url "https://github.com/grimme-lab/multicharge")
+set(_revision "v0.1.2")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
   if(DEFINED "${PROJECT_NAME}-dependency-method")
@@ -29,7 +30,7 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/dftd4-utils.cmake")
 
-dftd4_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}")
+dftd4_find_package("${_lib}" "${${_pkg}_FIND_METHOD}" "${_url}" "${_revision}")
 
 if(DEFINED "_${_pkg}_FIND_METHOD")
   unset("${_pkg}_FIND_METHOD")
@@ -38,3 +39,4 @@ endif()
 unset(_lib)
 unset(_pkg)
 unset(_url)
+unset(_revision)

--- a/config/cmake/dftd4-utils.cmake
+++ b/config/cmake/dftd4-utils.cmake
@@ -20,6 +20,7 @@ macro(
   package
   methods
   url
+  revision
 )
   string(TOLOWER "${package}" _pkg_lc)
   string(TOUPPER "${package}" _pkg_uc)
@@ -83,12 +84,12 @@ macro(
     endif()
 
     if("${method}" STREQUAL "fetch")
-      message(STATUS "Retrieving ${package} from ${url}")
+      message(STATUS "Retrieving ${package} revision ${revision} from ${url}")
       include(FetchContent)
       FetchContent_Declare(
         "${_pkg_lc}"
         GIT_REPOSITORY "${url}"
-        GIT_TAG "HEAD"
+        GIT_TAG "${revision}"
       )
       FetchContent_MakeAvailable("${_pkg_lc}")
 


### PR DESCRIPTION
I noticed that when mctc-lib, mstore and multicharge are fetched, cmake always fetched the head of the repository.

This patch adds some code to pin the fetched dependencies to the same versions specified in dftd4/subprojects/*.wrap

This helps make automated builds more reproducible, although it would be desirable to centralize versions in a single central file, or at least set them up as global CMake variables.