### PR TITLE
Add type generic macro for deleting API objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ To evaluate a dispersion correction in C four objects are available:
    Standard damping parameters like the rational damping are independent of the molecular structure and can easily be reused for several structures or easily exchanged.
 
 The user is responsible for creating and deleting the objects to avoid memory leaks.
+For convenience the type-generic macro ``dftd4_delete`` is available to free any memory allocation made in the library.
 
 
 ### Python API

--- a/include/dftd4.h
+++ b/include/dftd4.h
@@ -40,6 +40,17 @@ typedef struct _dftd4_model* dftd4_model;
 typedef struct _dftd4_param* dftd4_param;
 
 /*
+ * Type generic macro for convenience
+**/
+
+#define dftd4_delete(ptr) _Generic((ptr), \
+                       dftd4_error: dftd4_delete_error, \
+                   dftd4_structure: dftd4_delete_structure, \
+                       dftd4_model: dftd4_delete_model, \
+                       dftd4_param: dftd4_delete_param \
+                                  )(&ptr)
+
+/*
  * Global API queries
 **/
 

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ project(
   default_options: [
     'buildtype=debugoptimized',
     'default_library=both',
+    'c_std=c11',
   ],
 )
 install = not (meson.is_subproject() and get_option('default_library') == 'static')

--- a/test/api/example.c
+++ b/test/api/example.c
@@ -72,7 +72,7 @@ main (void)
    if (dftd4_check_error(error)) {return 1;}
    dftd4_get_pairwise_dispersion(error, mol, disp, param, pair_disp2, pair_disp3);
    if (dftd4_check_error(error)) {return 1;}
-   dftd4_delete_param(&param);
+   dftd4_delete(param);
 
    // DSD-BLYP-D4-ATM
    param = dftd4_load_rational_damping(error, "dsdblyp", true);
@@ -82,11 +82,11 @@ main (void)
    if (dftd4_check_error(error)) {return 1;}
    dftd4_get_dispersion(error, mol, disp, param, &energy, gradient, sigma);
    if (dftd4_check_error(error)) {return 1;}
-   dftd4_delete_param(&param);
+   dftd4_delete(param);
 
-   dftd4_delete_model(&disp);
-   dftd4_delete_structure(&mol);
-   dftd4_delete_error(&error);
+   dftd4_delete(disp);
+   dftd4_delete(mol);
+   dftd4_delete(error);
 
    assert(!param);
    assert(!disp);


### PR DESCRIPTION
- dispatch object handles to their respective deconstructor using _Generic
- automatically handle pass by reference of the object handle