### PR TITLE
Add workflow for building wheels

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,47 @@
+name: wheel
+
+on: [push, workflow_dispatch]
+
+jobs:
+  manylinux:
+    runs-on: ubuntu-latest
+    container: condaforge/linux-anvil-cos7-x86_64
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell || 'bash -l {0}' }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        path: python/subprojects/dftd4
+    - name: Create environment
+      run: >-
+        mamba create -n wheel
+        --yes
+        c-compiler
+        fortran-compiler
+        python=${{ matrix.python }}
+        auditwheel
+        --file assets/ci/wheel-req.txt
+    - name: Build wheel
+      run: |
+        conda activate wheel
+        set -ex
+        cp ../assets/parameters.toml dftd4
+        cp {mesonpep517,pyproject}.toml
+        python -m build . --wheel
+        auditwheel show dist/*.whl
+        auditwheel repair -w dist dist/*.whl --plat ${{ env.plat }}
+        rm dist/*-linux_x86_64.whl
+      env:
+        plat: manylinux${{ matrix.python == '3.6' && '2010' || '_2_12' }}_x86_64
+      working-directory: python
+    - uses: actions/upload-artifact@v3
+      with:
+        path: python/dist/*.whl

--- a/assets/ci/wheel-req.txt
+++ b/assets/ci/wheel-req.txt
@@ -1,0 +1,15 @@
+git
+python
+pip
+python-build
+pkgconfig
+patchelf
+cffi
+numpy
+ase
+qcelemental
+matplotlib-base
+liblapack
+meson
+unzip
+wheel

--- a/python/mesonpep517.toml
+++ b/python/mesonpep517.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["mesonpep517"]
+build-backend = "mesonpep517.buildapi"
+
+[tool.mesonpep517.metadata]
+author = "Sebastian Ehlert"
+author-email = "awvwgk@disroot.org"
+summary = "Python API of the DFT-D4 project"
+description-file = "README.rst"
+home-page = "https://github.com/dftd4/dftd4"
+requires = [
+   "cffi",
+   "numpy",
+]
+requires-python = ">=3.6"


### PR DESCRIPTION
Allows to build manylinux wheels for the Python bindings. Somewhat suboptimal since we have to redistribute OpenBLAS here, which makes the package huge (compared to a binary statically linked against MKL).