### PR TITLE
ILP64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ if(NOT TARGET "OpenMP::OpenMP_Fortran" AND WITH_OpenMP)
   find_package("OpenMP" REQUIRED)
 endif()
 
+if(WITH_ILP64)
+  message(STATUS "Using LAPACK/BLAS ILP64 interface")
+endif()
+
 if(NOT TARGET "BLAS::BLAS")
   find_package("custom-blas" REQUIRED)
 endif()
@@ -90,6 +94,16 @@ target_include_directories(
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/dftd4
 )
+
+if(WITH_ILP64)
+  target_compile_definitions(
+    "${PROJECT_NAME}-lib"
+    PUBLIC -DIK=i8)
+else()
+  target_compile_definitions(
+    "${PROJECT_NAME}-lib"
+    PUBLIC -DIK=i4)
+endif()
 
 # Add example application
 add_subdirectory("app")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,10 @@ if(NOT TARGET "OpenMP::OpenMP_Fortran" AND WITH_OpenMP)
   find_package("OpenMP" REQUIRED)
 endif()
 
-if(WITH_ILP64)
+if(WITH_ILP64 AND BLAS_LIBRARIES)
   message(STATUS "Using LAPACK/BLAS ILP64 interface")
+elseif(WITH_ILP64)
+  message(FATAL_ERROR "ILP64 support needs BLAS_LIBRARIES")
 endif()
 
 if(NOT TARGET "BLAS::BLAS")

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -18,6 +18,7 @@ option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
 
 option(WITH_API "Enable support for C API via iso_c_binding module" TRUE)
 option(WITH_OpenMP "Enable support for shared memory parallelisation with OpenMP" TRUE)
+option(WITH_ILP64 "Enable support for ILP64 BLAS/LAPACK calls" FALSE)
 option(WITH_API_V2 "Enable the compatibility layer for the dftd4 2.5.x API" FALSE)
 if(NOT DEFINED "${PROJECT_NAME}-dependeny-method")
   set(

--- a/config/meson.build
+++ b/config/meson.build
@@ -123,7 +123,7 @@ elif lapack_vendor == 'custom'
   lib_deps += custom_deps
 
 else
-  lapack_dep = dependency(ilp64 ? 'lapack64' : 'lapack', required: False)
+  lapack_dep = dependency(ilp64 ? 'lapack64' : 'lapack', required: false)
   if not lapack_dep.found()
     lapack_dep = fc.find_library(ilp64 ? 'lapack64' : 'lapack')
   endif

--- a/config/meson.build
+++ b/config/meson.build
@@ -54,15 +54,23 @@ if lapack_vendor == 'auto'
   endif
 endif
 
+if get_option('ilp64')
+  ilp64 = true
+  add_project_arguments('-DIK=i8', language:'fortran')
+else
+  add_project_arguments('-DIK=i4', language:'fortran')
+  ilp64 = false
+endif
+
 if lapack_vendor == 'mkl'
   mkl_dep = []
   if fc_id == 'intel'
-    mkl_dep += cc.find_library('mkl_intel_lp64')
+    mkl_dep += ilp64 ? cc.find_library('mkl_intel_ilp64') : cc.find_library('mkl_intel_lp64')
     if get_option('openmp')
       mkl_dep += cc.find_library('mkl_intel_thread')
     endif
   elif fc_id == 'gcc'
-    mkl_dep += cc.find_library('mkl_gf_lp64')
+    mkl_dep += ilp64 ? cc.find_library('mkl_gf_ilp64') : cc.find_library('mkl_gf_lp64')
     if get_option('openmp')
       mkl_dep += cc.find_library('mkl_gnu_thread')
     endif
@@ -80,33 +88,49 @@ elif lapack_vendor == 'mkl-rt'
   lib_deps += mkl_dep
 
 elif lapack_vendor == 'openblas'
-  openblas_dep = dependency('openblas', required: false)
+  openblas_dep = ilp64 ? dependency('openblas64', required: false) : dependency('openblas', required: false)
   if not openblas_dep.found()
-    openblas_dep = fc.find_library('openblas')
+    openblas_dep = ilp64 ? fc.find_library('openblas64') : fc.find_library('openblas')
   endif
   lib_deps += openblas_dep
   if not fc.links('external dsytrs; call dsytrs(); end', dependencies: openblas_dep)
     lapack_dep = dependency('lapack', required: false)
     if not lapack_dep.found()
-      lapack_dep = fc.find_library('lapack')
+      lapack_dep = ilp64 ? fc.find_library('lapack64') : fc.find_library('lapack')
     endif
     lib_deps += lapack_dep
   endif
 
 elif lapack_vendor == 'custom'
-  foreach lib: get_option('custom_libraries')
-    lib_deps += fc.find_library(lib)
-  endforeach
+  custom_deps = []
+  libs = get_option('custom_libraries')
+  if libs[0].startswith('-L')
+    foreach lib: libs
+      if lib != libs[0]
+        custom_deps += fc.find_library(lib, dirs: libs[0].substring(2))
+      endif
+    endforeach
+  else
+    foreach lib: libs
+      custom_deps += fc.find_library(lib)
+    endforeach
+  endif
+  if (not fc.links('external dsytrs; call dsytrs(); end', dependencies: [custom_deps,omp_dep]))
+    error('Custom LAPACK libraries do not link')
+  elif (not fc.links('external dsytrs; call dgemm(); end', dependencies: [custom_deps,omp_dep]))
+    error('Custom BLAS libraries do not link')
+  endif
+  lib_deps += custom_deps
 
 else
-  lapack_dep = dependency('lapack', required: false)
+  lapack_dep = ilp64 ? dependency('lapack64', required: False) : dependency('lapack', required: false)
   if not lapack_dep.found()
-    lapack_dep = fc.find_library('lapack')
+    lapack_dep = ilp64 ? fc.find_library('lapack64') : fc.find_library('lapack')
   endif
   lib_deps += lapack_dep
-  blas_dep = dependency('blas', required: false)
+  blas_dep = ilp64 ? fc.find_library('blas64', required: false) : dependency('blas', required: false)
   if not blas_dep.found()
-    blas_dep = fc.find_library('blas')
+    blas_dep = ilp64 ? fc.find_library('blas64') : fc.find_library('blas')
   endif
   lib_deps += blas_dep
 endif

--- a/config/meson.build
+++ b/config/meson.build
@@ -65,12 +65,12 @@ endif
 if lapack_vendor == 'mkl'
   mkl_dep = []
   if fc_id == 'intel'
-    mkl_dep += ilp64 ? cc.find_library('mkl_intel_ilp64') : cc.find_library('mkl_intel_lp64')
+    mkl_dep += cc.find_library(ilp64 ? 'mkl_intel_ilp64' : 'mkl_intel_lp64') 
     if get_option('openmp')
       mkl_dep += cc.find_library('mkl_intel_thread')
     endif
   elif fc_id == 'gcc'
-    mkl_dep += ilp64 ? cc.find_library('mkl_gf_ilp64') : cc.find_library('mkl_gf_lp64')
+    mkl_dep += cc.find_library(ilp64 ? 'mkl_gf_ilp64' : 'mkl_gf_lp64')
     if get_option('openmp')
       mkl_dep += cc.find_library('mkl_gnu_thread')
     endif
@@ -88,15 +88,15 @@ elif lapack_vendor == 'mkl-rt'
   lib_deps += mkl_dep
 
 elif lapack_vendor == 'openblas'
-  openblas_dep = ilp64 ? dependency('openblas64', required: false) : dependency('openblas', required: false)
+  openblas_dep = dependency( ilp64 ? 'openblas64' : 'openblas', required: false)
   if not openblas_dep.found()
-    openblas_dep = ilp64 ? fc.find_library('openblas64') : fc.find_library('openblas')
+    openblas_dep = fc.find_library( ilp64 ? 'openblas64' : 'openblas')
   endif
   lib_deps += openblas_dep
   if not fc.links('external dsytrs; call dsytrs(); end', dependencies: openblas_dep)
-    lapack_dep = dependency('lapack', required: false)
+    lapack_dep = dependency(ilp64 ? 'lapack64' : 'lapack', required: false)
     if not lapack_dep.found()
-      lapack_dep = ilp64 ? fc.find_library('lapack64') : fc.find_library('lapack')
+      lapack_dep = fc.find_library(ilp64 ? 'lapack64' : 'lapack')
     endif
     lib_deps += lapack_dep
   endif
@@ -123,14 +123,14 @@ elif lapack_vendor == 'custom'
   lib_deps += custom_deps
 
 else
-  lapack_dep = ilp64 ? dependency('lapack64', required: False) : dependency('lapack', required: false)
+  lapack_dep = dependency(ilp64 ? 'lapack64' : 'lapack', required: False)
   if not lapack_dep.found()
-    lapack_dep = ilp64 ? fc.find_library('lapack64') : fc.find_library('lapack')
+    lapack_dep = fc.find_library(ilp64 ? 'lapack64' : 'lapack')
   endif
   lib_deps += lapack_dep
-  blas_dep = ilp64 ? fc.find_library('blas64', required: false) : dependency('blas', required: false)
+  blas_dep = fc.find_library(ilp64 ? 'blas64' : 'blas', required: false)
   if not blas_dep.found()
-    blas_dep = ilp64 ? fc.find_library('blas64') : fc.find_library('blas')
+    blas_dep = fc.find_library(ilp64 ? 'blas64' : 'blas')
   endif
   lib_deps += blas_dep
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -66,3 +66,11 @@ option(
   value: false,
   description: 'Enable the compatibility layer for the dftd4 2.5.x API',
 )
+
+option(
+  'ilp64',
+  type: 'boolean',
+  value: false,
+  yield: true,
+  description: 'Enable BLAS/LAPACK ilp64 support',
+)

--- a/src/dftd4/CMakeLists.txt
+++ b/src/dftd4/CMakeLists.txt
@@ -21,7 +21,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 list(
   APPEND srcs
-  "${dir}/blas.f90"
+  "${dir}/blas.F90"
   "${dir}/charge.f90"
   "${dir}/cutoff.f90"
   "${dir}/damping.f90"

--- a/src/dftd4/blas.F90
+++ b/src/dftd4/blas.F90
@@ -15,8 +15,13 @@
 ! along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
 
 !> Interface to BLAS library
+
+#ifndef IK
+#define IK i4
+#endif
+
 module dftd4_blas
-   use mctc_env, only : sp, dp
+   use mctc_env, only : sp, dp, ik => IK
    implicit none
    private
 
@@ -47,32 +52,32 @@ module dftd4_blas
    !> m by n matrix.
    interface blas_gemv
       pure subroutine sgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
-         import :: sp
+         import :: sp, ik
+         integer(ik), intent(in) :: lda
          real(sp), intent(in) :: a(lda, *)
          real(sp), intent(in) :: x(*)
          real(sp), intent(inout) :: y(*)
          real(sp), intent(in) :: alpha
          real(sp), intent(in) :: beta
          character(len=1), intent(in) :: trans
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
       end subroutine sgemv
       pure subroutine dgemv(trans, m, n, alpha, a, lda, x, incx, beta, y, incy)
-         import :: dp
+         import :: dp, ik
+         integer(ik), intent(in) :: lda
          real(dp), intent(in) :: a(lda, *)
          real(dp), intent(in) :: x(*)
          real(dp), intent(inout) :: y(*)
          real(dp), intent(in) :: alpha
          real(dp), intent(in) :: beta
          character(len=1), intent(in) :: trans
-         integer, intent(in) :: incx
-         integer, intent(in) :: incy
-         integer, intent(in) :: m
-         integer, intent(in) :: n
-         integer, intent(in) :: lda
+         integer(ik), intent(in) :: incx
+         integer(ik), intent(in) :: incy
+         integer(ik), intent(in) :: m
+         integer(ik), intent(in) :: n
       end subroutine dgemv
    end interface blas_gemv
 
@@ -189,7 +194,7 @@ pure subroutine d4_sgemv(amat, xvec, yvec, alpha, beta, trans)
    character(len=1), intent(in), optional :: trans
    real(sp) :: a, b
    character(len=1) :: tra
-   integer :: incx, incy, m, n, lda
+   integer(ik) :: incx, incy, m, n, lda
    if (present(alpha)) then
       a = alpha
    else
@@ -223,7 +228,7 @@ pure subroutine d4_dgemv(amat, xvec, yvec, alpha, beta, trans)
    character(len=1), intent(in), optional :: trans
    real(dp) :: a, b
    character(len=1) :: tra
-   integer :: incx, incy, m, n, lda
+   integer(ik) :: incx, incy, m, n, lda
    if (present(alpha)) then
       a = alpha
    else

--- a/src/dftd4/meson.build
+++ b/src/dftd4/meson.build
@@ -18,7 +18,7 @@ subdir('damping')
 subdir('data')
 
 srcs += files(
-  'blas.f90',
+  'blas.F90',
   'charge.f90',
   'cutoff.f90',
   'damping.f90',


### PR DESCRIPTION
Adds support for BLAS/LAPACK ILP64.

`cmake`:  `-DWITH_ILP64` **and** `DBLAS_LIBRARIES` 
`meson`: `Dilp64=true`

Note that `multicharge` must also have `ILP64` support (grimme-lab/multicharge#16)