### PR TITLE
Export API routines for MSVC compiler

### DIFF
--- a/src/dftd4/api.f90
+++ b/src/dftd4/api.f90
@@ -88,6 +88,7 @@ contains
 !> Obtain library version as major * 10000 + minor + 100 + patch
 function get_version_api() result(version) &
       & bind(C, name=namespace//"get_version")
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_version_api
    integer(c_int) :: version
    integer :: major, minor, patch
 
@@ -101,6 +102,7 @@ end function get_version_api
 function new_error_api() &
       & result(verror) &
       & bind(C, name=namespace//"new_error")
+   !DEC$ ATTRIBUTES DLLEXPORT :: new_error_api
    type(vp_error), pointer :: error
    type(c_ptr) :: verror
 
@@ -115,6 +117,7 @@ end function new_error_api
 !> Delete error handle object
 subroutine delete_error_api(verror) &
       & bind(C, name=namespace//"delete_error")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delete_error_api
    type(c_ptr), intent(inout) :: verror
    type(vp_error), pointer :: error
 
@@ -133,6 +136,7 @@ end subroutine delete_error_api
 !> Check error handle status
 function check_error_api(verror) result(status) &
       & bind(C, name=namespace//"check_error")
+   !DEC$ ATTRIBUTES DLLEXPORT :: check_error_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    integer(c_int) :: status
@@ -157,6 +161,7 @@ end function check_error_api
 !> Get error message from error handle
 subroutine get_error_api(verror, charptr, buffersize) &
       & bind(C, name=namespace//"get_error")
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_error_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    character(kind=c_char), intent(inout) :: charptr(*)
@@ -186,6 +191,7 @@ end subroutine get_error_api
 function new_structure_api(verror, natoms, numbers, positions, c_charge, &
       & c_lattice, c_periodic) result(vmol) &
       & bind(C, name=namespace//"new_structure")
+   !DEC$ ATTRIBUTES DLLEXPORT :: new_structure_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    integer(c_int), value, intent(in) :: natoms
@@ -234,6 +240,7 @@ end function new_structure_api
 !> Delete molecular structure data
 subroutine delete_structure_api(vmol) &
       & bind(C, name=namespace//"delete_structure")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delete_structure_api
    type(c_ptr), intent(inout) :: vmol
    type(vp_structure), pointer :: mol
 
@@ -252,6 +259,7 @@ end subroutine delete_structure_api
 !> Update coordinates and lattice parameters (quantities in Bohr)
 subroutine update_structure_api(verror, vmol, positions, lattice) &
       & bind(C, name=namespace//"update_structure")
+   !DEC$ ATTRIBUTES DLLEXPORT :: update_structure_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    type(c_ptr), value :: vmol
@@ -294,6 +302,7 @@ end subroutine update_structure_api
 function new_d4_model_api(verror, vmol) &
       & result(vdisp) &
       & bind(C, name=namespace//"new_d4_model")
+   !DEC$ ATTRIBUTES DLLEXPORT :: new_d4_model_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    type(c_ptr), value :: vmol
@@ -325,6 +334,7 @@ end function new_d4_model_api
 function custom_d4_model_api(verror, vmol, ga, gc, wf) &
       & result(vdisp) &
       & bind(C, name=namespace//"custom_d4_model")
+   !DEC$ ATTRIBUTES DLLEXPORT :: custom_d4_model_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    type(c_ptr), value :: vmol
@@ -358,6 +368,7 @@ end function custom_d4_model_api
 !> Delete dispersion model
 subroutine delete_model_api(vdisp) &
       & bind(C, name=namespace//"delete_model")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delete_model_api
    type(c_ptr), intent(inout) :: vdisp
    type(vp_model), pointer :: disp
 
@@ -377,6 +388,7 @@ end subroutine delete_model_api
 function new_rational_damping_api(verror, s6, s8, s9, a1, a2, alp) &
       & result(vparam) &
       & bind(C, name=namespace//"new_rational_damping")
+   !DEC$ ATTRIBUTES DLLEXPORT :: new_rational_damping_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    real(c_double), value, intent(in) :: s6
@@ -410,6 +422,7 @@ end function new_rational_damping_api
 function load_rational_damping_api(verror, charptr, atm) &
       & result(vparam) &
       & bind(C, name=namespace//"load_rational_damping")
+   !DEC$ ATTRIBUTES DLLEXPORT :: load_rational_damping_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    character(kind=c_char), intent(in) :: charptr(*)
@@ -444,6 +457,7 @@ end function load_rational_damping_api
 !> Delete damping parameters
 subroutine delete_param_api(vparam) &
       & bind(C, name=namespace//"delete_param")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delete_param_api
    type(c_ptr), intent(inout) :: vparam
    type(vp_param), pointer :: param
 
@@ -463,6 +477,7 @@ end subroutine delete_param_api
 subroutine get_dispersion_api(verror, vmol, vdisp, vparam, &
       & energy, c_gradient, c_sigma) &
       & bind(C, name=namespace//"get_dispersion")
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_dispersion_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    type(c_ptr), value :: vmol
@@ -531,6 +546,7 @@ end subroutine get_dispersion_api
 subroutine get_pairwise_dispersion_api(verror, vmol, vdisp, vparam, &
       & c_pair_energy2, c_pair_energy3) &
       & bind(C, name=namespace//"get_pairwise_dispersion")
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_pairwise_dispersion_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    type(c_ptr), value :: vmol
@@ -585,6 +601,7 @@ end subroutine get_pairwise_dispersion_api
 subroutine get_properties_api(verror, vmol, vdisp, &
       & c_cn, c_charges, c_c6, c_alpha) &
       & bind(C, name=namespace//"get_properties")
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_properties_api
    type(c_ptr), value :: verror
    type(vp_error), pointer :: error
    type(c_ptr), value :: vmol

--- a/src/dftd4/charge.f90
+++ b/src/dftd4/charge.f90
@@ -32,6 +32,7 @@ contains
 
 !> Obtain charges from electronegativity equilibration model
 subroutine get_charges(mol, qvec, dqdr, dqdL)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_charges
 
    !> Molecular structure data
    type(structure_type), intent(in) :: mol

--- a/src/dftd4/cutoff.f90
+++ b/src/dftd4/cutoff.f90
@@ -118,6 +118,7 @@ end subroutine get_lattice_points_rep_3d
 
 !> Create lattice points within a given cutoff
 subroutine get_lattice_points_cutoff(periodic, lat, rthr, trans)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_lattice_points_cutoff
 
    !> Periodic dimensions
    logical, intent(in) :: periodic(:)

--- a/src/dftd4/damping/rational.f90
+++ b/src/dftd4/damping/rational.f90
@@ -58,6 +58,7 @@ contains
 !> Evaluation of the dispersion energy expression
 subroutine get_dispersion2(self, mol, trans, cutoff, r4r2, c6, dc6dcn, dc6dq, &
       & energy, dEdcn, dEdq, gradient, sigma)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_dispersion2
 
    !> Damping parameters
    class(rational_damping_param), intent(in) :: self
@@ -278,6 +279,7 @@ end subroutine get_dispersion_derivs
 !> Evaluation of the dispersion energy expression
 subroutine get_dispersion3(self, mol, trans, cutoff, r4r2, c6, dc6dcn, dc6dq, &
       & energy, dEdcn, dEdq, gradient, sigma)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_dispersion3
 
    !> Damping parameters
    class(rational_damping_param), intent(in) :: self
@@ -327,6 +329,7 @@ end subroutine get_dispersion3
 
 !> Evaluation of the dispersion energy expression projected on atomic pairs
 subroutine get_pairwise_dispersion2(self, mol, trans, cutoff, r4r2, c6, energy)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_pairwise_dispersion2
 
    !> Damping parameters
    class(rational_damping_param), intent(in) :: self
@@ -391,6 +394,7 @@ end subroutine get_pairwise_dispersion2
 
 !> Evaluation of the dispersion energy expression
 subroutine get_pairwise_dispersion3(self, mol, trans, cutoff, r4r2, c6, energy)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_pairwise_dispersion3
 
    !> Damping parameters
    class(rational_damping_param), intent(in) :: self

--- a/src/dftd4/data/covrad.f90
+++ b/src/dftd4/data/covrad.f90
@@ -69,6 +69,7 @@ contains
 
 !> Get covalent radius for a given element symbol
 elemental function get_covalent_rad_sym(sym) result(rad)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_covalent_rad_sym
 
    !> Element symbol
    character(len=*), intent(in) :: sym
@@ -83,6 +84,7 @@ end function get_covalent_rad_sym
 
 !> Get covalent radius for a given atomic number
 elemental function get_covalent_rad_num(num) result(rad)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_covalent_rad_num
 
    !> Atomic number
    integer, intent(in) :: num

--- a/src/dftd4/data/en.f90
+++ b/src/dftd4/data/en.f90
@@ -63,6 +63,7 @@ contains
 
 !> Get electronegativity for a given element symbol
 elemental function get_electronegativity_sym(sym) result(en)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_electronegativity_sym
 
    !> Element symbol
    character(len=*), intent(in) :: sym
@@ -77,6 +78,7 @@ end function get_electronegativity_sym
 
 !> Get electronegativity for a given atomic number
 elemental function get_electronegativity_num(num) result(en)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_electronegativity_num
 
    !> Atomic number
    integer, intent(in) :: num

--- a/src/dftd4/disp.f90
+++ b/src/dftd4/disp.f90
@@ -37,6 +37,7 @@ contains
 
 !> Wrapper to handle the evaluation of dispersion energy and derivatives
 subroutine get_dispersion(mol, disp, param, cutoff, energy, gradient, sigma)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_dispersion
 
    !> Molecular structure data
    class(structure_type), intent(in) :: mol
@@ -125,6 +126,7 @@ end subroutine get_dispersion
 
 !> Wrapper to handle the evaluation of properties related to this dispersion model
 subroutine get_properties(mol, disp, cutoff, cn, q, c6, alpha)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_properties
 
    !> Molecular structure data
    class(structure_type), intent(in) :: mol
@@ -168,6 +170,7 @@ end subroutine get_properties
 
 !> Wrapper to handle the evaluation of pairwise representation of the dispersion energy
 subroutine get_pairwise_dispersion(mol, disp, param, cutoff, energy2, energy3)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_pairwise_dispersion
 
    !> Molecular structure data
    class(structure_type), intent(in) :: mol

--- a/src/dftd4/model.f90
+++ b/src/dftd4/model.f90
@@ -118,6 +118,7 @@ contains
 
 !> Create new dispersion model from molecular structure input
 subroutine new_d4_model(self, mol, ga, gc, wf, ref)
+   !DEC$ ATTRIBUTES DLLEXPORT :: new_d4_model
 
    !> Instance of the dispersion model
    type(d4_model), intent(out) :: self
@@ -265,6 +266,7 @@ end subroutine new_d4_model
 !> Calculate the weights of the reference system and the derivatives w.r.t.
 !> coordination number for later use.
 subroutine weight_references(self, mol, cn, q, gwvec, gwdcn, gwdq)
+   !DEC$ ATTRIBUTES DLLEXPORT :: weight_references
 
    !> Instance of the dispersion model
    class(d4_model), intent(in) :: self
@@ -394,6 +396,7 @@ end function is_exceptional
 !> Calculate atomic dispersion coefficients and their derivatives w.r.t.
 !> the coordination numbers and atomic partial charges.
 subroutine get_atomic_c6(self, mol, gwvec, gwdcn, gwdq, c6, dc6dcn, dc6dq)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_atomic_c6
 
    !> Instance of the dispersion model
    class(d4_model), intent(in) :: self
@@ -490,7 +493,7 @@ end subroutine get_atomic_c6
 !> Calculate atomic polarizibilities and their derivatives w.r.t.
 !> the coordination numbers and atomic partial charges.
 subroutine get_polarizibilities(self, mol, gwvec, gwdcn, gwdq, alpha, dadcn, dadq)
-
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_polarizibilities
    !> Instance of the dispersion model
    class(d4_model), intent(in) :: self
 

--- a/src/dftd4/ncoord.f90
+++ b/src/dftd4/ncoord.f90
@@ -42,6 +42,7 @@ contains
 
 !> Geometric fractional coordination number, supports error function counting.
 subroutine get_coordination_number(mol, trans, cutoff, rcov, en, cn, dcndr, dcndL)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_coordination_number
 
    !> Molecular structure data
    type(structure_type), intent(in) :: mol

--- a/src/dftd4/output.f90
+++ b/src/dftd4/output.f90
@@ -36,6 +36,7 @@ contains
 
 
 subroutine ascii_atomic_radii(unit, mol, disp)
+   !DEC$ ATTRIBUTES DLLEXPORT :: ascii_atomic_radii
 
    !> Unit for output
    integer, intent(in) :: unit
@@ -68,6 +69,7 @@ end subroutine ascii_atomic_radii
 
 
 subroutine ascii_atomic_references(unit, mol, disp)
+   !DEC$ ATTRIBUTES DLLEXPORT :: ascii_atomic_references
 
    !> Unit for output
    integer, intent(in) :: unit
@@ -116,6 +118,7 @@ end subroutine ascii_atomic_references
 
 
 subroutine ascii_system_properties(unit, mol, disp, cn, q, c6)
+   !DEC$ ATTRIBUTES DLLEXPORT :: ascii_system_properties
 
    !> Unit for output
    integer, intent(in) :: unit
@@ -167,6 +170,7 @@ end subroutine ascii_system_properties
 
 
 subroutine ascii_results(unit, mol, energy, gradient, sigma)
+   !DEC$ ATTRIBUTES DLLEXPORT :: ascii_results
 
    !> Unit for output
    integer, intent(in) :: unit
@@ -218,6 +222,7 @@ end subroutine ascii_results
 
 
 subroutine ascii_pairwise(unit, mol, pair_disp2, pair_disp3)
+   !DEC$ ATTRIBUTES DLLEXPORT :: ascii_pairwise
 
    !> Unit for output
    integer, intent(in) :: unit
@@ -269,6 +274,7 @@ end subroutine ascii_pairwise
 
 
 subroutine ascii_damping_param(unit, param, method)
+   !DEC$ ATTRIBUTES DLLEXPORT :: ascii_damping_param
 
    !> Unit for output
    integer, intent(in) :: unit
@@ -303,6 +309,7 @@ end subroutine ascii_damping_param
 
 
 subroutine turbomole_gradlatt(mol, fname, energy, sigma, stat)
+   !DEC$ ATTRIBUTES DLLEXPORT :: turbomole_gradlatt
    type(structure_type),intent(in) :: mol
    character(len=*),intent(in) :: fname
    real(wp),intent(in) :: energy
@@ -392,6 +399,7 @@ end subroutine turbomole_gradlatt
 
 
 subroutine turbomole_gradient(mol, fname, energy, gradient, stat)
+   !DEC$ ATTRIBUTES DLLEXPORT :: turbomole_gradient
    type(structure_type),intent(in) :: mol
    character(len=*),intent(in) :: fname
    real(wp),intent(in) :: energy
@@ -503,6 +511,7 @@ end subroutine getline
 
 subroutine json_results(unit, indentation, energy, gradient, sigma, cn, q, c6, alpha, &
       & pairwise_energy2, pairwise_energy3)
+   !DEC$ ATTRIBUTES DLLEXPORT :: json_results
    integer, intent(in) :: unit
    character(len=*), intent(in), optional :: indentation
    real(wp), intent(in), optional :: energy
@@ -610,6 +619,7 @@ end subroutine write_json_array
 
 
 subroutine tagged_result(unit, energy, gradient, sigma)
+   !DEC$ ATTRIBUTES DLLEXPORT :: tagged_result
    integer, intent(in) :: unit
    real(wp), intent(in), optional :: energy
    real(wp), intent(in), optional :: gradient(:, :)

--- a/src/dftd4/param.f90
+++ b/src/dftd4/param.f90
@@ -58,6 +58,7 @@ module dftd4_param
 contains
 
 subroutine get_rational_damping(functional, param, s9)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_rational_damping
    character(len=*), intent(in) :: functional
    class(damping_param), allocatable, intent(out) :: param
    real(wp), intent(in), optional :: s9

--- a/src/dftd4/utils.f90
+++ b/src/dftd4/utils.f90
@@ -26,6 +26,7 @@ contains
 
 
 subroutine wrap_to_central_cell(xyz, lattice, periodic)
+   !DEC$ ATTRIBUTES DLLEXPORT :: wrap_to_central_cell
    real(wp), intent(inout) :: xyz(:, :)
    real(wp), intent(in) :: lattice(:, :)
    logical, intent(in) :: periodic(:)

--- a/src/dftd4/version.f90
+++ b/src/dftd4/version.f90
@@ -35,6 +35,7 @@ contains
 
 !> Getter function to retrieve dftd4 version
 subroutine get_dftd4_version(major, minor, patch, string)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_dftd4_version
 
    !> Major version number of the dftd4 version
    integer, intent(out), optional :: major


### PR DESCRIPTION
* Exports must be explictly declared for the MSVC compiler. This commit adds DLLEXPORT attributes to the subroutines needed for the api and app to compile

Signed-off-by: Ty <ty.balduf@schrodinger.com>

This still the same pull request as https://github.com/dftd4/dftd4/pull/168. Had to remake due to clunky choice of branching