### PR TITLE
PySCF: Capture dispersion energy in scf_summary

### DIFF
--- a/python/dftd4/pyscf.py
+++ b/python/dftd4/pyscf.py
@@ -209,7 +209,9 @@ def energy(mf):
         def energy_nuc(self) -> float:
             enuc = mf.__class__.energy_nuc(self)
             if self.with_dftd4:
-                enuc += self.with_dftd4.kernel()[0]
+                edisp = self.with_dftd4.kernel()[0]
+                self.scf_summary["dispersion"] = edisp
+                enuc += edisp
             return enuc
 
         def reset(self, mol=None) -> "DFTD4":

--- a/python/dftd4/test_pyscf.py
+++ b/python/dftd4/test_pyscf.py
@@ -121,6 +121,7 @@ def test_energy_hf():
     )
     mf = disp.energy(scf.RHF(mol))
     assert mf.kernel() == approx(-110.91742452859162, abs=1.0e-8)
+    assert "dispersion" in mf.scf_summary
 
 
 @pytest.mark.skipif(pyscf is None, reason="requires pyscf")


### PR DESCRIPTION
Allows to correctly print PySCF the dispersion contribution from a `mf` object.

See See https://github.com/pyscf/pyscf/blob/8b3fef8cf18f10d430261d4a8bea21fadf19bb1f/pyscf/scf/hf.py#L1054-L1076.

Closes #192 
Requires #194 