### PR TITLE
Fix passing atomic numbers from PySCF to D4 interface

### DIFF
--- a/python/dftd4/pyscf.py
+++ b/python/dftd4/pyscf.py
@@ -21,8 +21,7 @@ Compatibility layer for supporting DFT-D4 in `pyscf <https://pyscf.org/>`_.
 """
 
 try:
-    from pyscf import lib
-    from pyscf.data.elements import charge as sym2chrg
+    from pyscf import lib, gto
     from pyscf.grad import rhf as rhf_grad
 except ModuleNotFoundError:
     raise ModuleNotFoundError("This submodule requires pyscf installed")
@@ -102,7 +101,7 @@ class DFTD4Dispersion(lib.StreamObject):
         mol = self.mol
 
         disp = DispersionModel(
-            np.asarray([sym2chrg(sym) for sym in mol.elements]),
+            np.asarray([gto.charge(sym) for sym in mol.elements]),
             mol.atom_coords(),
             mol.charge,
         )

--- a/python/dftd4/pyscf.py
+++ b/python/dftd4/pyscf.py
@@ -21,16 +21,17 @@ Compatibility layer for supporting DFT-D4 in `pyscf <https://pyscf.org/>`_.
 """
 
 try:
-    from pyscf import lib, gto
+    from pyscf import lib
+    from pyscf.data.elements import charge as sym2chrg
     from pyscf.grad import rhf as rhf_grad
 except ModuleNotFoundError:
     raise ModuleNotFoundError("This submodule requires pyscf installed")
 
-import numpy as np
 from typing import Tuple
 
-from .interface import DispersionModel, DampingParam
+import numpy as np
 
+from .interface import DampingParam, DispersionModel
 
 GradientsBase = getattr(rhf_grad, "GradientsBase", rhf_grad.Gradients)
 
@@ -101,7 +102,7 @@ class DFTD4Dispersion(lib.StreamObject):
         mol = self.mol
 
         disp = DispersionModel(
-            mol.atom_charges(),
+            np.asarray([sym2chrg(sym) for sym in mol.elements]),
             mol.atom_coords(),
             mol.charge,
         )
@@ -177,8 +178,8 @@ def energy(mf):
     -110.917424528592
     """
 
-    from pyscf.scf import hf
     from pyscf.mcscf import casci
+    from pyscf.scf import hf
 
     if not isinstance(mf, (hf.SCF, casci.CASCI)):
         raise TypeError("mf must be an instance of SCF or CASCI")

--- a/python/dftd4/test_pyscf.py
+++ b/python/dftd4/test_pyscf.py
@@ -14,20 +14,23 @@
 # You should have received a copy of the Lesser GNU General Public License
 # along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
 
+from typing import Union
+
 import numpy as np
 import pytest
 from pytest import approx
 
 try:
+    import dftd4.pyscf as disp
     import pyscf
     from pyscf import gto, scf
-    import dftd4.pyscf as disp
 except ModuleNotFoundError:
     pyscf = None
 
 
 @pytest.mark.skipif(pyscf is None, reason="requires pyscf")
-def test_energy_r2scan_d4():
+@pytest.mark.parametrize("ecp", [None, "ccecp"])
+def test_energy_r2scan_d4(ecp: Union[None, str]) -> None:
     mol = gto.M(
         atom="""
              C   -0.755422531  -0.796459123  -1.023590391
@@ -48,7 +51,8 @@ def test_energy_r2scan_d4():
              H   -1.684433029   7.115457372  -0.460265708
              H   -2.683867206   5.816530502  -1.115183775
              H   -3.365330613   7.451201412  -0.890098894
-             """
+             """,
+        ecp=ecp,
     )
 
     d4 = disp.DFTD4Dispersion(mol, xc="r2SCAN")
@@ -56,7 +60,7 @@ def test_energy_r2scan_d4():
 
 
 @pytest.mark.skipif(pyscf is None, reason="requires pyscf")
-def test_gradient_b97m_d4():
+def test_gradient_b97m_d4() -> None:
     mol = gto.M(
         atom="""
              H    0.002144194   0.361043475   0.029799709
@@ -105,7 +109,7 @@ def test_gradient_b97m_d4():
 
 
 @pytest.mark.skipif(pyscf is None, reason="requires pyscf")
-def test_energy_hf():
+def test_energy_hf() -> None:
     mol = gto.M(
         atom="""
              N  -1.57871857  -0.04661102   0.00000000
@@ -124,7 +128,7 @@ def test_energy_hf():
 
 
 @pytest.mark.skipif(pyscf is None, reason="requires pyscf")
-def test_gradient_hf():
+def test_gradient_hf() -> None:
     mol = gto.M(
         atom="""
              O  -1.65542061  -0.12330038   0.00000000


### PR DESCRIPTION
- use atomic symbols and [pyscf's charge function](https://github.com/pyscf/pyscf/blob/bf0b1db22556a3c1b4c34426ea8627e636c1b096/pyscf/data/elements.py#L1136) for obtaining atomic numbers