### PR TITLE
Treat Intel LLVM compiler as standard Intel compiler (#252)

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -20,8 +20,9 @@ cc = fc
 if has_cc
   cc = meson.get_compiler('c')
 endif
-# Treat Intel LLVM compiler as standard Intel compiler for compatibility
 fc_id = fc.get_id()
+
+# Treat Intel LLVM compiler as standard Intel compiler for compatibility
 if fc_id == 'intel-llvm'
   fc_id = 'intel'
 endif

--- a/config/meson.build
+++ b/config/meson.build
@@ -20,8 +20,11 @@ cc = fc
 if has_cc
   cc = meson.get_compiler('c')
 endif
+# Treat Intel LLVM compiler as standard Intel compiler for compatibility
 fc_id = fc.get_id()
-
+if fc_id == 'intel-llvm'
+  fc_id = 'intel'
+endif
 if fc_id == 'gcc'
   add_project_arguments(
     '-ffree-line-length-none',


### PR DESCRIPTION
These changes ensure that the Intel LLVM compiler is treated as the standard Intel compiler, addressing specific compatibility issues we've encountered.