### PR TITLE
Update VASP linking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,13 @@ To enable support for D4 in Vasp add the following lines to the Makefile:
 
 ```make
 CPP_OPTIONS += -DDFTD4
-LLIBS       += $(shell pkg-config --libs dftd4)
+LLIBS       += $(shell pkg-config --libs dftd4) -lmulticharge -lmctc-lib -lmstore
 INCS        += $(shell pkg-config --cflags dftd4)
 ```
+
+The ``-lmulticharge -lmctc-lib -lmstore`` libraries are dependencies of ``dftd4`` and have to be linked as well.
+
+If you still run into issues, check out [VASP-related issues](https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20) on the ``dftd4`` issue tracker.
 
 
 ### C API

--- a/README.md
+++ b/README.md
@@ -341,11 +341,9 @@ To enable support for D4 in Vasp add the following lines to the Makefile:
 
 ```make
 CPP_OPTIONS += -DDFTD4
-LLIBS       += $(shell pkg-config --libs dftd4) -lmulticharge -lmctc-lib -lmstore
-INCS        += $(shell pkg-config --cflags dftd4)
+LLIBS       += $(shell pkg-config --libs dftd4 multicharge mctc-lib)
+INCS        += $(shell pkg-config --cflags dftd4 multicharge mctc-lib)
 ```
-
-The ``-lmulticharge -lmctc-lib -lmstore`` libraries are dependencies of ``dftd4`` and have to be linked as well.
 
 If you still run into issues, check out [VASP-related issues](https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20) on the ``dftd4`` issue tracker.
 

--- a/doc/recipe/vasp.rst
+++ b/doc/recipe/vasp.rst
@@ -47,5 +47,9 @@ To enable support for D4 in Vasp add the following lines to the Makefile:
 .. code-block:: make
 
    CPP_OPTIONS += -DDFTD4
-   LLIBS       += $(shell pkg-config --libs dftd4)
+   LLIBS       += $(shell pkg-config --libs dftd4) -lmulticharge -lmctc-lib -lmstore
    INCS        += $(shell pkg-config --cflags dftd4)
+
+The ``-lmulticharge -lmctc-lib -lmstore`` libraries are dependencies of ``dftd4`` and have to be linked as well.
+
+If you still run into issues, check out `VASP-related issues <https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20>`_ on the ``dftd4`` issue tracker.

--- a/doc/recipe/vasp.rst
+++ b/doc/recipe/vasp.rst
@@ -47,9 +47,7 @@ To enable support for D4 in Vasp add the following lines to the Makefile:
 .. code-block:: make
 
    CPP_OPTIONS += -DDFTD4
-   LLIBS       += $(shell pkg-config --libs dftd4) -lmulticharge -lmctc-lib -lmstore
-   INCS        += $(shell pkg-config --cflags dftd4)
-
-The ``-lmulticharge -lmctc-lib -lmstore`` libraries are dependencies of ``dftd4`` and have to be linked as well.
+   LLIBS       += $(shell pkg-config --libs dftd4 multicharge mctc-lib)
+   INCS        += $(shell pkg-config --cflags dftd4 multicharge mctc-lib)
 
 If you still run into issues, check out `VASP-related issues <https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20>`_ on the ``dftd4`` issue tracker.


### PR DESCRIPTION
See #216. As suggested by https://github.com/dftd4/dftd4/issues/216#issuecomment-2632529681.