### PR TITLE
Update VASP build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ INCS        += $(shell pkg-config --cflags dftd4)
 If you still run into issues, check out [VASP-related issues](https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20) on the ``dftd4`` issue tracker.
 
 
-
 ### C API
 
 The C API provides access to the basic Fortran objects and their most important methods to interact with them.

--- a/README.md
+++ b/README.md
@@ -341,11 +341,20 @@ To enable support for D4 in Vasp add the following lines to the Makefile:
 
 ```make
 CPP_OPTIONS += -DDFTD4
-LLIBS       += $(shell pkg-config --libs dftd4 multicharge mctc-lib)
-INCS        += $(shell pkg-config --cflags dftd4 multicharge mctc-lib)
+LLIBS       += $(shell pkg-config --libs dftd4)
+INCS        += $(shell pkg-config --cflags dftd4)
+```
+
+Depending on how you built DFT-D4, DFT-D4's dependencies might not be properly recognized during the VASP build. Try to explicitly add them to the link line.
+
+```make
+CPP_OPTIONS += -DDFTD4
+LLIBS       += $(shell pkg-config --libs dftd4) -lmulticharge -lmctc-lib -lmstore
+INCS        += $(shell pkg-config --cflags dftd4)
 ```
 
 If you still run into issues, check out [VASP-related issues](https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20) on the ``dftd4`` issue tracker.
+
 
 
 ### C API

--- a/doc/recipe/vasp.rst
+++ b/doc/recipe/vasp.rst
@@ -47,7 +47,16 @@ To enable support for D4 in Vasp add the following lines to the Makefile:
 .. code-block:: make
 
    CPP_OPTIONS += -DDFTD4
-   LLIBS       += $(shell pkg-config --libs dftd4 multicharge mctc-lib)
-   INCS        += $(shell pkg-config --cflags dftd4 multicharge mctc-lib)
+   LLIBS       += $(shell pkg-config --libs dftd4)
+   INCS        += $(shell pkg-config --cflags dftd4)
+
+Depending on how you built DFT-D4, DFT-D4's dependencies not might be properly recognized during the VASP build. Try to explicitly add them to the link line.
+
+.. code-block:: make
+
+   CPP_OPTIONS += -DDFTD4
+   LLIBS       += $(shell pkg-config --libs dftd4) -lmulticharge -lmctc-lib -lmstore
+   INCS        += $(shell pkg-config --cflags dftd4)
+```
 
 If you still run into issues, check out `VASP-related issues <https://github.com/dftd4/dftd4/issues?q=label%3Avasp%20>`_ on the ``dftd4`` issue tracker.


### PR DESCRIPTION
Revert #279 because instructions failed for other users. Only add hint if linking fails.