### PR TITLE
Bump setup-fpm to v7

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Install fpm
         if: ${{ matrix.build == 'fpm' }}
-        uses: fortran-lang/setup-fpm@v5
+        uses: fortran-lang/setup-fpm@v7  # fpm 0.11.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Older versions always pull the latest fpm version, which now breaks after compiler name was added to the release artifacts (see https://github.com/fortran-lang/fpm/issues/1104).