### PR TITLE
Replace Ubuntu 20.04 with 22.04

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -62,7 +62,7 @@ jobs:
             build: cmake
             build-type: debug
             compiler: gnu
-            version: 8
+            version: 9
 
           - os: macos-13
             build: cmake

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -58,7 +58,7 @@ jobs:
         version: [12]
 
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             build: cmake
             build-type: debug
             compiler: gnu


### PR DESCRIPTION
Ubuntu 20.04 runners are discontinued and GCC8 is not on 22.04 anymore.