### PR TITLE
fix accessing parameters in windows

### DIFF
--- a/python/dftd4/parameters.py
+++ b/python/dftd4/parameters.py
@@ -55,7 +55,7 @@ def get_data_file_name(base_name: str = "parameters.toml") -> str:
     if not exists(data_file):
         # for Windows install layout
         data_file = join(
-            dirname(__file__), "..", "..", "..", "Library", "share", "s-dftd3", base_name
+            dirname(__file__), "..", "..", "..", "Library", "share", "dftd4", base_name
         )
         if not exists(data_file):
             data_file = join(dirname(__file__), base_name)

--- a/python/dftd4/parameters.py
+++ b/python/dftd4/parameters.py
@@ -47,7 +47,6 @@ def get_data_file_name(base_name: str = "parameters.toml") -> str:
 
     If we don't find the parameter file there we might be standalone and ship
     our own data base file in the same directory as this source file.
-    Or we might be on Windows where accessed from $PREFIX/Lib/site-packages/dftd4.
     """
 
     data_file = join(

--- a/python/dftd4/parameters.py
+++ b/python/dftd4/parameters.py
@@ -47,6 +47,7 @@ def get_data_file_name(base_name: str = "parameters.toml") -> str:
 
     If we don't find the parameter file there we might be standalone and ship
     our own data base file in the same directory as this source file.
+    Or we might be on Windows where accessed from $PREFIX/Lib/site-packages/dftd4.
     """
 
     data_file = join(

--- a/python/dftd4/parameters.py
+++ b/python/dftd4/parameters.py
@@ -55,7 +55,7 @@ def get_data_file_name(base_name: str = "parameters.toml") -> str:
     if not exists(data_file):
         # for Windows install layout
         data_file = join(
-            dirname(__file__), "..", "..", "..", "Library", "share", "dftd4", base_name
+            dirname(__file__), "..", "..", "..", "Library", "share",  "dftd4", base_name
         )
         if not exists(data_file):
             data_file = join(dirname(__file__), base_name)

--- a/python/dftd4/parameters.py
+++ b/python/dftd4/parameters.py
@@ -55,7 +55,7 @@ def get_data_file_name(base_name: str = "parameters.toml") -> str:
     if not exists(data_file):
         # for Windows install layout
         data_file = join(
-            dirname(__file__), "..", "..", "..", "Library", "share",  "dftd4", base_name
+            dirname(__file__), "..", "..", "..", "Library", "share", "dftd4", base_name
         )
         if not exists(data_file):
             data_file = join(dirname(__file__), base_name)


### PR DESCRIPTION
The Windows fix #268 has a small typo that produces confusing results :-)

All the tests really do pass (see 84e3c1bf7548d8faf45d34aff4333428e5d84a51). I'm having trouble getting them all passing at once.