### PR TITLE
Dynamic load balancing for ATM

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,23 @@ dftd4 --pair-resolved mol.xyz
 For an overview over all command line arguments use the `--help` argument or checkout the [`dftd4(1)`](https://github.com/dftd4/dftd4/blob/main/man/dftd4.1.adoc) manpage.
 
 
+### Parallelism
+
+DFT-D4 calculations can be performed with shared-memory parallelism (OpenMP).
+
+The number of parallel threads can be set through environment variables.
+
+```sh
+export OMP_NUM_THREADS=4
+export MKL_NUM_THREADS=4  # Intel
+```
+
+For large calculations, additional speed-ups might be possible by enabling dynamic scheduling in OMP by setting `OMP_SCHEDULE=dynamic`.
+This might help particularly for versions <4.0.0 ([explanation](https://github.com/dftd4/dftd4/pull/319)).
+
+Note that DFT-D4 is not MPI parallelized.
+
+
 ## Parameters
 
 DFT-D4 is parametrized for plenty of density functionals.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,7 +25,7 @@ DFT-D4 dispersion correction
    :target: https://codecov.io/gh/dftd4/dftd4
    :alt: Coverage
 
-This pages describe the usage and functionality of `dftd4`_ library.
+These pages describe usage and functionality of the `dftd4`_ library.
 The *dftd4* project provides an implementation of the generally applicable, charge dependent London-dispersion correction, termed DFT-D4.
 
 .. _dftd4: https://github.com/dftd4/dftd4

--- a/src/dftd4/damping/atm.f90
+++ b/src/dftd4/damping/atm.f90
@@ -150,7 +150,7 @@ subroutine get_atm_dispersion_energy(mol, trans, cutoff, s9, a1, a2, alp, r4r2, 
    !$omp shared(energy) &
    !$omp private(energy_local)
    allocate(energy_local(size(energy, 1)), source=0.0_wp)
-   !$omp do schedule(runtime)
+   !$omp do schedule(dynamic)
    do iat = 1, mol%nat
       izp = mol%id(iat)
       do jat = 1, iat
@@ -289,7 +289,7 @@ subroutine get_atm_dispersion_derivs(mol, trans, cutoff, s9, a1, a2, alp, r4r2, 
    allocate(dEdq_local(size(dEdq, 1)), source=0.0_wp)
    allocate(gradient_local(size(gradient, 1), size(gradient, 2)), source=0.0_wp)
    allocate(sigma_local(size(sigma, 1), size(sigma, 2)), source=0.0_wp)
-   !$omp do schedule(runtime)
+   !$omp do schedule(dynamic)
    do iat = 1, mol%nat
       izp = mol%id(iat)
       do jat = 1, iat


### PR DESCRIPTION
The workload in the triple loop of the ATM term is maximally unbalanced:
- first iteration: all loops have a length of 1
- last iteration: all loops have length `<number of atoms>`

Currently, OMP scheduling is decided at runtime (`OMP_SCHEDULE` environment variable). Depending on the compiler and whether the environment variable is set or not, `static` scheduling is likely selected ([source 1](https://github.com/dftd4/dftd4/pull/262#discussion_r1825349470), [source 2](https://stackoverflow.com/questions/61638747/default-scheduling-in-openmp-gcc-compiler)). Given the unbalanced workload, `dynamic` scheduling should always be faster here.

Instead of having the user figure this out, we now explicitly employ `dynamic` scheduling for the ATM term.