### PR TITLE
Restrict coverage to core library

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,8 @@
 fixes:
   - "/home/runner/work/dftd4/dftd4::"
 
-# Only cover core library
+# Only cover core library (`app` and `src` directories)
 ignore:
-  - "app/"
   - "assets/"
   - "build/"
   - "config/"
@@ -13,4 +12,3 @@ ignore:
   - "python/"
   - "subprojects/"
   - "test/"
-

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,16 @@
 fixes:
   - "/home/runner/work/dftd4/dftd4::"
+
+# Only cover core library
+ignore:
+  - "app/"
+  - "assets/"
+  - "build/"
+  - "config/"
+  - "doc/"
+  - "include/"
+  - "man/"
+  - "python/"
+  - "subprojects/"
+  - "test/"
+

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -326,9 +326,17 @@ jobs:
         env:
           OMP_NUM_THREADS: 1,2,1
 
+      # Use gcovr for more control instead of `ninja -C $BUILD_DIR coverage`.
+      # Option `--include-internal-functions` required to cover mangled Fortran
+      # symbols (e.g., `__dftd4_damping_rational_MOD_get_dispersion2`). 
       - name: Create coverage report
         if: ${{ matrix.build == 'meson' && matrix.build-type == 'coverage' }}
-        run: ninja -C $BUILD_DIR coverage
+        run: |
+          gcovr $BUILD_DIR \
+            --root . \
+            --include-internal-functions
+            -e "subprojects/" -e "test/"
+            -x -o coverage.xml
         env:
           BUILD_DIR: ${{ env.BUILD_DIR }}
 
@@ -372,6 +380,9 @@ jobs:
         if: ${{ matrix.build == 'meson' && matrix.build-type == 'coverage' }}
         uses: codecov/codecov-action@v7
         with:
+          fail_ci_if_error: false
+          files: coverage.xml
+          flags: fortran
           token: ${{ secrets.CODECOV_TOKEN }}
 
   python:

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -334,8 +334,8 @@ jobs:
         run: |
           gcovr $BUILD_DIR \
             --root . \
-            --include-internal-functions
-            -e "subprojects/" -e "test/"
+            --include-internal-functions \
+            -e "subprojects/" -e "test/" \
             -x -o coverage.xml
         env:
           BUILD_DIR: ${{ env.BUILD_DIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@
 **/install*/
 /_*/
 
+# Coverage
+coverage*
+*.gcov
+
 # Meson build system files
 *.wraplock
 


### PR DESCRIPTION
Proper coverage metrics. Exclude tests, subprojects, etc.