### PR TITLE
Enable building Python API with CMake

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -58,6 +58,8 @@ jobs:
           retention-days: 5
 
   sdist:
+    needs:
+      - source
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -67,6 +69,11 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Download source distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: dftd4-source
 
       - name: Install LAPACK
         run: |
@@ -90,13 +97,17 @@ jobs:
         run: |
           git config user.email ""
           git config user.name "dummy"
-          git subtree add --prefix python/subprojects/dftd4 . HEAD
+          mkdir -p python/subprojects/dftd4
+          tar -xJf dftd4-*.tar.xz \
+            --strip-components=1 \
+            -C python/subprojects/dftd4
+          git add --force python/subprojects/dftd4
           git mv {assets,python/dftd4}/parameters.toml
           git commit -m "Python dist"
 
       - name: Build source distribution
         run: |
-          python -m build python/ --sdist --outdir . -n -Cdist-args="--include-subprojects"
+          python -m build python/ --sdist --outdir . -n
 
       - name: Upload source distribution as artifact
         uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,14 @@ add_subdirectory("app")
 add_library("${PROJECT_NAME}" INTERFACE)
 add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 target_link_libraries("${PROJECT_NAME}" INTERFACE "${PROJECT_NAME}-lib")
+
+if(DFTD4_WITH_PYTHON)
+  if(NOT DFTD4_WITH_API)
+    message(FATAL_ERROR "DFTD4_WITH_PYTHON requires DFTD4_WITH_API")
+  endif()
+  add_subdirectory("python")
+endif()
+
 install(
   TARGETS
   "${PROJECT_NAME}"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ Alternatively, this project can be build with CMake (in this case ninja 1.10 or 
 cmake -B _build -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local
 ```
 
+The Python extension can be enabled with
+
+```sh
+cmake -B _build -G Ninja \
+  -DDFTD4_WITH_PYTHON=ON \
+  -DPython3_EXECUTABLE=$(which python3)
+```
+
+Building the Python extension requires CMake 3.18 or newer and the Python
+`cffi` and `setuptools` packages.
+
 To compile the project with CMake run
 
 ```
@@ -171,9 +182,6 @@ Finally, you can install the project to the selected prefix
 ```
 cmake --install _build
 ```
-
-Note that the CMake build does not support to build the Python extension module as part of the main build.
-
 
 #### Building with fpm
 
@@ -414,10 +422,18 @@ For convenience the type-generic macro ``dftd4_delete`` is available to free any
 
 The Python API is disabled by default and can be built in-tree or out-of-tree.
 The in-tree build is mainly meant for end users and packages.
-To build the Python API with the normal project set the `python` option in the configuration step with
+To build the Python API with Meson, set the `python` option in the configuration step with
 
 ```sh
 meson setup _build -Dpython=true -Dpython_version=$(which python3)
+```
+
+With CMake, use
+
+```sh
+cmake -B _build -G Ninja \
+  -DDFTD4_WITH_PYTHON=ON \
+  -DPython3_EXECUTABLE=$(which python3)
 ```
 
 The Python version can be used to select a different Python version, it defaults to `'python3'`.

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -32,6 +32,7 @@ option(DFTD4_WITH_API "Enable support for C API via iso_c_binding module" ${WITH
 option(DFTD4_WITH_OpenMP "Enable support for shared memory parallelisation with OpenMP" ${WITH_OpenMP})
 option(DFTD4_WITH_ILP64 "Enable support for ILP64 BLAS/LAPACK calls" ${WITH_ILP64})
 option(DFTD4_WITH_API_V2 "Enable the compatibility layer for the dftd4 2.5.x API" ${WITH_API_V2})
+option(DFTD4_WITH_PYTHON "Build the Python extension module" FALSE)
 set(DFTD4_USE_MULTICHARGE TRUE)
 set(DFTD4_USE_MCTCLIB TRUE)
 if(NOT DEFINED "${PROJECT_NAME}-dependency-method")

--- a/doc/recipe/installation.rst
+++ b/doc/recipe/installation.rst
@@ -153,6 +153,10 @@ Configure the CMake build with
 
    cmake -B_build -GNinja -DCMAKE_INSTALL_PREFIX=/path/to/installation
 
+The Python extension can be enabled with CMake 3.18 or newer by adding
+``-DDFTD4_WITH_PYTHON=ON`` and selecting the interpreter with
+``-DPython3_EXECUTABLE=/path/to/python3``.
+
 Similar to meson the compiler can be selected with the ``FC`` environment variable.
 You can build the project using
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,6 +16,8 @@
 
 cmake_minimum_required(VERSION 3.18)
 
+include(GNUInstallDirs)
+
 set(_dftd4_python_standalone FALSE)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(_dftd4_python_standalone TRUE)
@@ -140,13 +142,15 @@ endif()
 
 execute_process(
   COMMAND
-  "${Python3_EXECUTABLE}"
-  -c
-  "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '', 'platbase': ''}).lstrip('/'))"
+    "${Python3_EXECUTABLE}"
+    -c
+    "import sysconfig, sys; print(sysconfig.get_path('platlib', vars={'base': '', 'platbase': '', 'platlibdir': sys.argv[1]}).lstrip('/'))"
+    "${CMAKE_INSTALL_LIBDIR}"
   OUTPUT_VARIABLE _dftd4_python_install_root
   OUTPUT_STRIP_TRAILING_WHITESPACE
   RESULT_VARIABLE _dftd4_sysconfig_status
 )
+
 if(NOT _dftd4_sysconfig_status EQUAL 0)
   message(FATAL_ERROR "Could not determine the Python platform-library directory")
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,194 @@
+# This file is part of dftd4.
+# SPDX-Identifier: LGPL-3.0-or-later
+#
+# dftd4 is free software: you can redistribute it and/or modify it under
+# the terms of the Lesser GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# dftd4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Lesser GNU General Public License for more details.
+#
+# You should have received a copy of the Lesser GNU General Public License
+# along with dftd4.  If not, see <https://www.gnu.org/licenses/>.
+
+cmake_minimum_required(VERSION 3.18)
+
+set(_dftd4_python_standalone FALSE)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(_dftd4_python_standalone TRUE)
+  project(
+    dftd4-python
+    LANGUAGES C
+    VERSION 4.2.0
+    DESCRIPTION "Python API of the DFT-D4 project"
+  )
+endif()
+
+find_package(Python3 3.7 REQUIRED COMPONENTS "Interpreter" "Development.Module")
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c "import cffi, setuptools"
+  RESULT_VARIABLE _dftd4_cffi_status
+  ERROR_QUIET
+)
+if(NOT _dftd4_cffi_status EQUAL 0)
+  message(FATAL_ERROR
+    "The Python interpreter does not provide the cffi and setuptools modules"
+  )
+endif()
+
+set(_dftd4_target "")
+set(_dftd4_include_dir "")
+
+# An in-tree build already provides the native target. A standalone Python
+# build first tries an installed CMake package and then the source bundled in
+# the Python sdist.
+if(TARGET dftd4::dftd4)
+  set(_dftd4_target "dftd4::dftd4")
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../include/dftd4.h")
+    set(_dftd4_include_dir "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  endif()
+elseif(TARGET dftd4::dftd4-lib)
+  set(_dftd4_target "dftd4::dftd4-lib")
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../include/dftd4.h")
+    set(_dftd4_include_dir "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+  endif()
+elseif(_dftd4_python_standalone)
+  find_package(dftd4 "${PROJECT_VERSION}" CONFIG QUIET)
+  if(TARGET dftd4::dftd4)
+    set(_dftd4_target "dftd4::dftd4")
+  elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/subprojects/dftd4/CMakeLists.txt")
+    set(BUILD_SHARED_LIBS FALSE CACHE BOOL "Build shared libraries" FORCE)
+    set(DFTD4_WITH_API TRUE CACHE BOOL "Build the DFT-D4 C API" FORCE)
+    set(DFTD4_WITH_PYTHON FALSE CACHE BOOL "Build the DFT-D4 Python API" FORCE)
+    add_subdirectory("subprojects/dftd4" "subprojects/dftd4")
+    set(_dftd4_target "dftd4::dftd4")
+    set(_dftd4_include_dir "${CMAKE_CURRENT_SOURCE_DIR}/subprojects/dftd4/include")
+  endif()
+endif()
+
+if(NOT _dftd4_target)
+  message(FATAL_ERROR
+    "Could not find dftd4 >= ${PROJECT_VERSION}; install its CMake package "
+    "or build from a Python sdist containing subprojects/dftd4"
+  )
+endif()
+if(DEFINED DFTD4_WITH_API AND NOT DFTD4_WITH_API)
+  message(FATAL_ERROR "The dftd4 Python extension requires the dftd4 C API")
+endif()
+
+if(NOT _dftd4_include_dir)
+  get_target_property(
+    _dftd4_interface_include_dirs
+    "${_dftd4_target}"
+    INTERFACE_INCLUDE_DIRECTORIES
+  )
+  unset(_dftd4_include_dir)
+  unset(_dftd4_include_dir CACHE)
+  find_path(
+    _dftd4_include_dir
+    NAMES "dftd4.h"
+    HINTS ${_dftd4_interface_include_dirs}
+  )
+  if(NOT _dftd4_include_dir)
+    message(FATAL_ERROR "Could not locate dftd4.h from ${_dftd4_target}")
+  endif()
+endif()
+
+set(_dftd4_header "${CMAKE_CURRENT_SOURCE_DIR}/include/_dftd4.h")
+set(_dftd4_preprocessed_header "${CMAKE_CURRENT_BINARY_DIR}/_libdftd4.h")
+set(_dftd4_cffi_source "${CMAKE_CURRENT_BINARY_DIR}/_libdftd4.c")
+
+# CFFI cannot parse all preprocessor constructs in the public C header.
+add_custom_command(
+  OUTPUT "${_dftd4_preprocessed_header}"
+  COMMAND
+  "${CMAKE_C_COMPILER}"
+  "-I${_dftd4_include_dir}"
+  "-DDFTD4_CFFI"
+  "-E"
+  "${_dftd4_header}"
+  "-o"
+  "${_dftd4_preprocessed_header}"
+  DEPENDS
+  "${_dftd4_header}"
+  "${_dftd4_include_dir}/dftd4.h"
+  VERBATIM
+)
+
+add_custom_command(
+  OUTPUT "${_dftd4_cffi_source}"
+  COMMAND
+  "${Python3_EXECUTABLE}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ffibuilder.py"
+  "${_dftd4_preprocessed_header}"
+  "_libdftd4"
+  DEPENDS
+  "${_dftd4_preprocessed_header}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ffibuilder.py"
+  VERBATIM
+)
+
+Python3_add_library("_libdftd4" MODULE WITH_SOABI "${_dftd4_cffi_source}")
+target_include_directories("_libdftd4" PRIVATE "${_dftd4_include_dir}")
+target_link_libraries("_libdftd4" PRIVATE "${_dftd4_target}")
+if(CMAKE_Fortran_COMPILER_LOADED)
+  set_property(TARGET "_libdftd4" PROPERTY LINKER_LANGUAGE "Fortran")
+endif()
+
+execute_process(
+  COMMAND
+  "${Python3_EXECUTABLE}"
+  -c
+  "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '', 'platbase': ''}).lstrip('/'))"
+  OUTPUT_VARIABLE _dftd4_python_install_root
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _dftd4_sysconfig_status
+)
+if(NOT _dftd4_sysconfig_status EQUAL 0)
+  message(FATAL_ERROR "Could not determine the Python platform-library directory")
+endif()
+set(
+  DFTD4_PYTHON_INSTALL_DIR
+  "${_dftd4_python_install_root}/dftd4"
+  CACHE PATH
+  "Directory for the dftd4 Python package"
+)
+
+install(
+  TARGETS "_libdftd4"
+  LIBRARY DESTINATION "${DFTD4_PYTHON_INSTALL_DIR}"
+  COMPONENT "python"
+  RUNTIME DESTINATION "${DFTD4_PYTHON_INSTALL_DIR}"
+  COMPONENT "python"
+)
+
+set(
+  _dftd4_python_sources
+  "dftd4/__init__.py"
+  "dftd4/ase.py"
+  "dftd4/data.py"
+  "dftd4/interface.py"
+  "dftd4/library.py"
+  "dftd4/parameters.py"
+  "dftd4/pyscf.py"
+  "dftd4/qcschema.py"
+  "dftd4/references.json"
+  "dftd4/test_ase.py"
+  "dftd4/test_interface.py"
+  "dftd4/test_library.py"
+  "dftd4/test_parameters.py"
+  "dftd4/test_pyscf.py"
+  "dftd4/test_qcschema.py"
+)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dftd4/parameters.toml")
+  list(APPEND _dftd4_python_sources "dftd4/parameters.toml")
+endif()
+
+install(
+  FILES ${_dftd4_python_sources}
+  DESTINATION "${DFTD4_PYTHON_INSTALL_DIR}"
+  COMPONENT "python"
+)

--- a/python/README.rst
+++ b/python/README.rst
@@ -245,8 +245,10 @@ Now you are ready to use ``dftd4``, check if you can import it with
 Building the extension module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To perform an out-of-tree build some version of ``dftd4`` has to be available on your system and preferably findable by ``pkg-config``.
-Try to find a ``dftd4`` installation you build against first with
+The released Python source distribution bundles the native ``dftd4`` sources.
+When building directly from the repository, an installed ``dftd4`` must be
+available through CMake or ``pkg-config``, depending on the selected build
+system. Try to find the installation first with
 
 .. code:: sh
 
@@ -291,6 +293,22 @@ If you already have a ``dftd4`` installation, *e.g.* from conda-forge, you can b
 .. code:: sh
 
    pip install "https://github.com/dftd4/dftd4/archive/refs/heads/main#egg=dftd4-python&subdirectory=python"
+
+
+Using CMake
+^^^^^^^^^^^
+
+This directory contains a standalone CMake build for the CFFI extension.
+It first looks for an installed ``dftd4`` CMake package and then for a bundled
+``subprojects/dftd4`` source tree, as provided by the Python source distribution.
+It requires CMake 3.18 or newer and Python 3.7 or newer with ``cffi`` and
+``setuptools`` installed.
+
+.. code:: sh
+
+   cmake -S . -B _build -G Ninja -DPython3_EXECUTABLE=$(which python3)
+   cmake --build _build
+   cmake --install _build --prefix=/path/to/install --component python
 
 
 


### PR DESCRIPTION
This adds CMake support for building the Python API and addresses #380:
- Add the `DFTD4_WITH_PYTHON` option for building the Python extension as part of the main CMake project.
- Add a standalone `python/CMakeLists.txt` for building the CFFI extension against an in-tree, installed, or bundled dftd4 library.
- Document the corresponding CMake build procedure.